### PR TITLE
mark support transaction as completed

### DIFF
--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -203,6 +203,10 @@ export function doSendSupport(amount, claimId, uri, successCallback, errorCallba
         })
       );
 
+      dispatch({
+        type: ACTIONS.SUPPORT_TRANSACTION_COMPLETED,
+      });
+
       if (successCallback) {
         successCallback();
       }


### PR DESCRIPTION
While investigating the 0LBC doSendSupport issue (lbry-app #738) I noticed that if I sent a tip, I had to restart the app to send another, because this wasn't being dispatched.