### PR TITLE
handle doSendSupport error like complete

### DIFF
--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -212,6 +212,26 @@ export function doSendSupport(amount, claimId, uri, successCallback, errorCallba
       }
     };
 
+    const error = err => {
+      dispatch(
+        doNotify({
+          message: __(`There was an error sending support funds.`),
+          displayType: ['snackbar'],
+        })
+      );
+
+      dispatch({
+        type: ACTIONS.SUPPORT_TRANSACTION_FAILED,
+        data: {
+          error: err,
+        },
+      });
+
+      if (errorCallback) {
+        errorCallback();
+      }
+    };
+
     dispatch({
       type: ACTIONS.SUPPORT_TRANSACTION_STARTED,
     });
@@ -219,6 +239,6 @@ export function doSendSupport(amount, claimId, uri, successCallback, errorCallba
     Lbry.wallet_send({
       claim_id: claimId,
       amount,
-    }).then(success, errorCallback);
+    }).then(success, error);
   };
 }


### PR DESCRIPTION
I copied the pattern from support payment completion. It displays the error in the snackbar and resets `state.wallet.sendingSupport` to false so when a user clicks "send a tip" again, the Send button in the modal is enabled.

Disabling of the Send button until the amount is positive coming soon in the app repo...