### PR TITLE
Add function to convert an URI to  an url that can be shared and opened with lbry-app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export {
   isURIValid,
   isURIClaimable,
   isNameValid,
+  convertToShareLink,
 } from 'lbryURI';
 
 // actions

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -230,12 +230,5 @@ export function isURIClaimable(URI) {
 }
 
 export function convertToShareLink(URI) {
-  if (URI.match(/pending_claim/)) return URI;
-
-  const { claimName, path, bidPosition, claimSequence, claimId } = parseURI(URI);
-  return buildURI(
-    { claimName, path, claimSequence, bidPosition, claimId },
-    true,
-    'https://open.lbry.io/'
-  );
+  return buildURI(parseURI(URI), true, 'https://open.lbry.io/');
 }

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -145,7 +145,7 @@ export function parseURI(URI, requireProto = false) {
  *
  * The channelName key will accept names with or without the @ prefix.
  */
-export function buildURI(URIObj, includeProto = true) {
+export function buildURI(URIObj, includeProto = true, protoDefault = 'lbry://') {
   const { claimId, claimSequence, bidPosition, contentName, channelName } = URIObj;
 
   let { claimName, path } = URIObj;
@@ -179,7 +179,7 @@ export function buildURI(URIObj, includeProto = true) {
   }
 
   return (
-    (includeProto ? 'lbry://' : '') +
+    (includeProto ? protoDefault : '') +
     claimName +
     (claimId ? `#${claimId}` : '') +
     (claimSequence ? `:${claimSequence}` : '') +
@@ -226,5 +226,16 @@ export function isURIClaimable(URI) {
     !parts.claimSequence &&
     !parts.isChannel &&
     !parts.path
+  );
+}
+
+export function convertToShareLink(URI) {
+  if (URI.match(/pending_claim/)) return URI;
+
+  const { claimName, path, bidPosition, claimSequence, claimId } = parseURI(URI);
+  return buildURI(
+    { claimName, path, claimSequence, bidPosition, claimId },
+    true,
+    'https://open.lbry.io/'
   );
 }


### PR DESCRIPTION
This function will parse a lbry URI and convert it to an https protocol, Let me know if this is the correct place to add it, we may need to use it on lbry-android sometime(tap on a video to share an url or something like that)
This PR is needed for [PR on lbry-app#1486](https://github.com/lbryio/lbry-app/pull/1486)
So for example given this URI:
`lbry://why-doesn-t-capitalism-work-for#36cd5b217bcc4083a6fc35cc4de2cc1196581ef9`
changes to:
`https://open.lbry.io/why-doesn-t-capitalism-work-for#36cd5b217bcc4083a6fc35cc4de2cc1196581ef9`