### PR TITLE
do not reset search query on HISTORY_NAVIGATE

### DIFF
--- a/src/redux/reducers/search.js
+++ b/src/redux/reducers/search.js
@@ -88,7 +88,6 @@ export const searchReducer = handleActions(
     // if going home, it should be blank
     [ACTIONS.HISTORY_NAVIGATE]: (state: SearchState): SearchState => ({
       ...state,
-      searchQuery: '',
       suggestions: [],
       isActive: false,
     }),


### PR DESCRIPTION
This was breaking the back button fix I'm working on for [lbry-app/issues/1457](https://github.com/lbryio/lbry-app/issues/1457)