### PR TITLE
filter search suggestions so the search query isn't suggested twice

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -3832,12 +3832,6 @@ var getSearchSuggestions = exports.getSearchSuggestions = function getSearchSugg
         value: claimName,
         type: SEARCH_TYPES.SEARCH
       });
-
-      // If it's a valid url, don't fetch any extra search results
-      dispatch({
-        type: ACTIONS.UPDATE_SEARCH_SUGGESTIONS,
-        data: { suggestions: suggestions }
-      });
     } catch (e) {
       suggestions.push({
         value: query,
@@ -3861,7 +3855,9 @@ var getSearchSuggestions = exports.getSearchSuggestions = function getSearchSugg
 
     fetch('https://lighthouse.lbry.io/autocomplete?s=' + searchValue).then(_handleFetch2.default).then(function (apiSuggestions) {
       // Suggestion could be a channel, uri, or search term
-      var formattedSuggestions = apiSuggestions.slice(0, 6).map(function (suggestion) {
+      var formattedSuggestions = apiSuggestions.slice(0, 6).filter(function (suggestion) {
+        return suggestion !== query;
+      }).map(function (suggestion) {
         if (suggestion.includes(' ')) {
           return {
             value: suggestion,

--- a/src/redux/actions/search.js
+++ b/src/redux/actions/search.js
@@ -107,12 +107,6 @@ export const getSearchSuggestions = (value: string) => dispatch => {
         type: SEARCH_TYPES.SEARCH,
       }
     );
-
-    // If it's a valid url, don't fetch any extra search results
-    dispatch({
-      type: ACTIONS.UPDATE_SEARCH_SUGGESTIONS,
-      data: { suggestions },
-    });
   } catch (e) {
     suggestions.push({
       value: query,
@@ -138,31 +132,34 @@ export const getSearchSuggestions = (value: string) => dispatch => {
     .then(handleFetchResponse)
     .then(apiSuggestions => {
       // Suggestion could be a channel, uri, or search term
-      const formattedSuggestions = apiSuggestions.slice(0, 6).map(suggestion => {
-        if (suggestion.includes(' ')) {
-          return {
-            value: suggestion,
-            type: SEARCH_TYPES.SEARCH,
-          };
-        }
+      const formattedSuggestions = apiSuggestions
+        .slice(0, 6)
+        .filter(suggestion => suggestion !== query)
+        .map(suggestion => {
+          if (suggestion.includes(' ')) {
+            return {
+              value: suggestion,
+              type: SEARCH_TYPES.SEARCH,
+            };
+          }
 
-        try {
-          const uri = normalizeURI(suggestion);
-          const { claimName, isChannel } = parseURI(uri);
+          try {
+            const uri = normalizeURI(suggestion);
+            const { claimName, isChannel } = parseURI(uri);
 
-          return {
-            value: uri,
-            shorthand: isChannel ? claimName.slice(1) : claimName,
-            type: isChannel ? SEARCH_TYPES.CHANNEL : SEARCH_TYPES.FILE,
-          };
-        } catch (e) {
-          // search result includes some character that isn't valid in claim names
-          return {
-            value: suggestion,
-            type: SEARCH_TYPES.SEARCH,
-          };
-        }
-      });
+            return {
+              value: uri,
+              shorthand: isChannel ? claimName.slice(1) : claimName,
+              type: isChannel ? SEARCH_TYPES.CHANNEL : SEARCH_TYPES.FILE,
+            };
+          } catch (e) {
+            // search result includes some character that isn't valid in claim names
+            return {
+              value: suggestion,
+              type: SEARCH_TYPES.SEARCH,
+            };
+          }
+        });
 
       suggestions = suggestions.concat(formattedSuggestions);
       dispatch({


### PR DESCRIPTION
If the search suggestion api returns a query that is the same as the one the user typed in the search bar, we should remove it so there aren't two identical search suggestions.

Fixes https://github.com/lbryio/lbry-app/issues/1495