### PR TITLE
Fix convertToShareLink

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1319,7 +1319,14 @@ function isURIClaimable(URI) {
 }
 
 function convertToShareLink(URI) {
-  return buildURI(parseURI(URI), true, 'https://open.lbry.io/');
+  var _parseURI2 = parseURI(URI),
+      claimName = _parseURI2.claimName,
+      path = _parseURI2.path,
+      bidPosition = _parseURI2.bidPosition,
+      claimSequence = _parseURI2.claimSequence,
+      claimId = _parseURI2.claimId;
+
+  return buildURI({ claimName: claimName, path: path, claimSequence: claimSequence, bidPosition: bidPosition, claimId: claimId }, true, 'https://open.lbry.io/');
 }
 
 /***/ }),

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -230,5 +230,6 @@ export function isURIClaimable(URI) {
 }
 
 export function convertToShareLink(URI) {
-  return buildURI(parseURI(URI), true, 'https://open.lbry.io/');
+  const { claimName, path, bidPosition, claimSequence, claimId } = parseURI(URI);
+  return buildURI({ claimName, path, claimSequence, bidPosition, claimId }, true, 'https://open.lbry.io/');
 }


### PR DESCRIPTION
Pass correct values to builduri. Otherwise, you get this when right clicking something:
```
Uncaught Error: Received a channel content URI, but claim name and channelName do not match. "name" represents the value in the name position of the URI (lbry://name...), which for channel content will be the channel name. In most cases, to construct a channel URI you should just pass channelName and contentName.
    at buildURI (C:\Program Files\LBRY\resources\app.asar\node_modules\lbry-redux\dist\bundle.js:126
```

@dan1d did you run into this during your testing?