### PR TITLE
update search query/activity when navigating

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -46,17 +46,32 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// define getter function for harmony exports
 /******/ 	__webpack_require__.d = function(exports, name, getter) {
 /******/ 		if(!__webpack_require__.o(exports, name)) {
-/******/ 			Object.defineProperty(exports, name, {
-/******/ 				configurable: false,
-/******/ 				enumerable: true,
-/******/ 				get: getter
-/******/ 			});
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
 /******/ 		}
 /******/ 	};
 /******/
 /******/ 	// define __esModule on exports
 /******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
 /******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
 /******/ 	};
 /******/
 /******/ 	// getDefaultExport function for compatibility with non-harmony modules
@@ -1351,14 +1366,9 @@ var _action_types = __webpack_require__(4);
 
 var ACTIONS = _interopRequireWildcard(_action_types);
 
-var _Notification = __webpack_require__(1);
-
-var _Notification2 = _interopRequireDefault(_Notification);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
+/*:: import type {Notification} from 'types/Notification';*/
 function doNotify(notification /*: Notification*/, notificationProps /*: NotificationProps*/) {
   return {
     type: ACTIONS.CREATE_NOTIFICATION,
@@ -5390,6 +5400,14 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
   suggestions: Array<SearchSuggestion>,
   urisByQuery: {},
 };*/
+/*:: type HistoryNavigate = {
+  type: ACTIONS.HISTORY_NAVIGATE,
+  data: {
+    url: string,
+    index?: number,
+    scrollY?: number
+  }
+}*/
 
 
 var defaultState = {
@@ -5427,11 +5445,13 @@ var searchReducer = exports.searchReducer = (0, _reduxUtils.handleActions)((_han
   return _extends({}, state, {
     suggestions: action.data.suggestions
   });
-}), _defineProperty(_handleActions, ACTIONS.HISTORY_NAVIGATE, function (state /*: SearchState*/) /*: SearchState*/ {
+}), _defineProperty(_handleActions, ACTIONS.HISTORY_NAVIGATE, function (state /*: SearchState*/, action /*: HistoryNavigate*/) /*: SearchState*/ {
+  var url = action.data.url;
+
   return _extends({}, state, {
-    searchQuery: '',
+    searchQuery: url.indexOf('/search') === 0 ? url.slice(14) : '',
     suggestions: [],
-    isActive: false
+    isActive: url.indexOf('/search') === 0
   });
 }), _defineProperty(_handleActions, ACTIONS.DISMISS_NOTIFICATION, function (state /*: SearchState*/) /*: SearchState*/ {
   return _extends({}, state, {

--- a/src/redux/reducers/search.js
+++ b/src/redux/reducers/search.js
@@ -37,6 +37,15 @@ type SearchState = {
   urisByQuery: {},
 };
 
+type HistoryNavigate = {
+  type: ACTIONS.HISTORY_NAVIGATE,
+  data: {
+    url: string,
+    index?: number,
+    scrollY?: number,
+  },
+};
+
 const defaultState = {
   isActive: false, // does the user have any typed text in the search input
   focused: false, // is the search input focused
@@ -83,15 +92,17 @@ export const searchReducer = handleActions(
       suggestions: action.data.suggestions,
     }),
 
-    // clear the searchQuery on back/forward
-    // it may be populated by the page title for search/file pages
-    // if going home, it should be blank
-    [ACTIONS.HISTORY_NAVIGATE]: (state: SearchState): SearchState => ({
-      ...state,
-      searchQuery: '',
-      suggestions: [],
-      isActive: false,
-    }),
+    // clear the searchQuery on back/forward unless to search page
+    [ACTIONS.HISTORY_NAVIGATE]: (state: SearchState, action: HistoryNavigate): SearchState => {
+      const { url } = action.data;
+      return {
+        ...state,
+        searchQuery: url.indexOf('/search') === 0 ? url.slice(14) : '',
+        suggestions: [],
+        isActive: url.indexOf('/search') === 0,
+      };
+    },
+
     // sets isActive to false so the uri will be populated correctly if the
     // user is on a file page. The search query will still be present on any
     // other page


### PR DESCRIPTION
Setting the search query blank removed the results from the search page. Not setting it blank leaves it there when a user navigates to a search result. This PR fixes both cases: if navigating to the search page, update the query based on the uri, otherwise clear the query.