### PR TITLE
Fix getMediaType logic

### DIFF
--- a/src/lbry.js
+++ b/src/lbry.js
@@ -110,9 +110,7 @@ Lbry.connect = () => {
 };
 
 Lbry.getMediaType = (contentType, fileName) => {
-  if (contentType) {
-    return /^[^/]+/.exec(contentType)[0];
-  } else if (fileName) {
+  if (fileName) {
     const formats = [
       [/^.+\.(mp4|m4v|webm|flv|f4v|ogv)$/i, 'video'],
       [/^.+\.(mp3|m4a|aac|wav|flac|ogg|opus)$/i, 'audio'],
@@ -128,7 +126,9 @@ Lbry.getMediaType = (contentType, fileName) => {
       }
     }, fileName);
     return res === fileName ? 'unknown' : res;
-  }
+  } else if (contentType) {
+    return /^[^/]+/.exec(contentType)[0];
+  } 
   return 'unknown';
 };
 

--- a/src/lbry.js
+++ b/src/lbry.js
@@ -109,13 +109,13 @@ Lbry.connect = () => {
   return Lbry.connectPromise;
 };
 
-Lbry.getMediaType = (contentType, fileName) => {
-  if (fileName) {
+Lbry.getMediaType = (contentType, extname) => {
+  if (extname) {
     const formats = [
-      [/^.+\.(mp4|m4v|webm|flv|f4v|ogv)$/i, 'video'],
-      [/^.+\.(mp3|m4a|aac|wav|flac|ogg|opus)$/i, 'audio'],
-      [/^.+\.(html|htm|xml|pdf|odf|doc|docx|md|markdown|txt|epub|org)$/i, 'document'],
-      [/^.+\.(stl|obj|fbx|gcode)$/i, '3D-file'],
+      [/^(mp4|m4v|webm|flv|f4v|ogv)$/i, 'video'],
+      [/^(mp3|m4a|aac|wav|flac|ogg|opus)$/i, 'audio'],
+      [/^(html|htm|xml|pdf|odf|doc|docx|md|markdown|txt|epub|org)$/i, 'document'],
+      [/^(stl|obj|fbx|gcode)$/i, '3D-file'],
     ];
     const res = formats.reduce((ret, testpair) => {
       switch (testpair[0].test(ret)) {
@@ -124,8 +124,8 @@ Lbry.getMediaType = (contentType, fileName) => {
         default:
           return ret;
       }
-    }, fileName);
-    return res === fileName ? 'unknown' : res;
+    }, extname);
+    return res === extname ? 'unknown' : res;
   } else if (contentType) {
     return /^[^/]+/.exec(contentType)[0];
   } 


### PR DESCRIPTION
### Changes
- Improve media type detection of files with a `contentType` similar to `application/something`         

### Example
Most files don't follow  a standar mime-type.
 A simple `.pdf` file can contain a vendor-specific mime-type:
```
 PDF -> application/x-pdf, application/pdf, application/octet-stream
```

### Usage 
Before:
```JS
  const mediaType =
    (fileInfo && Lbry.getMediaType(null, fileInfo.file_name)) || Lbry.getMediaType(contentType);
```
After:
```JS
  const extname = path.extname(fileName) || mime.getExtension(contenType);
  const mediaType = Lbry.getMediaType(contentType, extname);
```
Required by:
https://github.com/lbryio/lbry-app/pull/1576
https://github.com/lbryio/lbry-app/pull/1558