### PR TITLE
fix: strip out related content properly on vanity uris

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -3312,13 +3312,20 @@ var makeSelectNsfwCountForChannel = exports.makeSelectNsfwCountForChannel = func
 
 var makeSelectRecommendedContentForUri = exports.makeSelectRecommendedContentForUri = function makeSelectRecommendedContentForUri(uri) {
   return (0, _reselect.createSelector)(makeSelectClaimForUri(uri), _search.selectSearchUrisByQuery, function (claim, searchUrisByQuery) {
-    var recommendedContent = void 0;
+    var atVanityURI = !uri.includes('#');
 
+    var recommendedContent = void 0;
     if (claim) {
       var title = claim.value.stream.metadata.title;
 
       var searchUris = searchUrisByQuery[title.replace(/\//, ' ')];
       if (searchUris) {
+        // If we are at a vanity uri, we can't do a uri match
+        // The first search result _should_ be the same as the claim a user is on
+        if (atVanityURI) {
+          searchUris = searchUris.slice(1);
+        }
+
         searchUris = searchUris.filter(function (searchUri) {
           return searchUri !== uri;
         });

--- a/src/redux/selectors/claims.js
+++ b/src/redux/selectors/claims.js
@@ -267,8 +267,9 @@ export const makeSelectRecommendedContentForUri = uri =>
     makeSelectClaimForUri(uri),
     selectSearchUrisByQuery,
     (claim, searchUrisByQuery) => {
-      let recommendedContent;
+      const atVanityURI = !uri.includes('#');
 
+      let recommendedContent;
       if (claim) {
         const {
           value: {
@@ -279,6 +280,12 @@ export const makeSelectRecommendedContentForUri = uri =>
         } = claim;
         let searchUris = searchUrisByQuery[title.replace(/\//, ' ')];
         if (searchUris) {
+          // If we are at a vanity uri, we can't do a uri match
+          // The first search result _should_ be the same as the claim a user is on
+          if (atVanityURI) {
+            searchUris = searchUris.slice(1);
+          }
+
           searchUris = searchUris.filter(searchUri => searchUri !== uri);
           recommendedContent = searchUris;
         }


### PR DESCRIPTION
When getting the recommended content for vanity uris, we can't do a uri match because it won't include a claim id. Just strip out the first result since it should be the same claim.