### PR TITLE
delete claim from byId while it's in pending status

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -5253,6 +5253,7 @@ reducers[ACTIONS.FETCH_CLAIM_LIST_MINE_COMPLETED] = function (state, action) {
     if (claim.type && claim.type.match(/claim|update/)) {
       if (claim.confirmations < 1) {
         pendingById[claim.claim_id] = claim;
+        delete byId[claim.claim_id];
       } else {
         byId[claim.claim_id] = claim;
       }

--- a/src/redux/reducers/claims.js
+++ b/src/redux/reducers/claims.js
@@ -58,6 +58,7 @@ reducers[ACTIONS.FETCH_CLAIM_LIST_MINE_COMPLETED] = (state, action) => {
     if (claim.type && claim.type.match(/claim|update/)) {
       if (claim.confirmations < 1) {
         pendingById[claim.claim_id] = claim;
+        delete byId[claim.claim_id];
       } else {
         byId[claim.claim_id] = claim;
       }


### PR DESCRIPTION
This allows us to avoid duplicates when selectingMyClaims, which will pull from `byId` and `pendingById`