### PR TITLE
search for exact url when filtering related results

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -3365,18 +3365,16 @@ var makeSelectRecommendedContentForUri = exports.makeSelectRecommendedContentFor
 
     var recommendedContent = void 0;
     if (claim) {
+      // If we are at a vanity uri, build the full uri so we can properly filter
+      var currentUri = atVanityURI ? (0, _lbryURI.buildURI)({ claimId: claim.claim_id, claimName: claim.name }) : uri;
+
       var title = claim.value.stream.metadata.title;
+
 
       var searchUris = searchUrisByQuery[title.replace(/\//, ' ')];
       if (searchUris) {
-        // If we are at a vanity uri, we can't do a uri match
-        // The first search result _should_ be the same as the claim a user is on
-        if (atVanityURI) {
-          searchUris = searchUris.slice(1);
-        }
-
         searchUris = searchUris.filter(function (searchUri) {
-          return searchUri !== uri;
+          return searchUri !== currentUri;
         });
         recommendedContent = searchUris;
       }

--- a/src/redux/selectors/claims.js
+++ b/src/redux/selectors/claims.js
@@ -293,22 +293,16 @@ export const makeSelectRecommendedContentForUri = (uri) =>
 
       let recommendedContent;
       if (claim) {
-        const {
-          value: {
-            stream: {
-              metadata: { title },
-            },
-          },
-        } = claim;
+        // If we are at a vanity uri, build the full uri so we can properly filter
+        const currentUri = atVanityURI
+          ? buildURI({ claimId: claim.claim_id, claimName: claim.name })
+          : uri;
+
+        const { title } = claim.value.stream.metadata;
+
         let searchUris = searchUrisByQuery[title.replace(/\//, ' ')];
         if (searchUris) {
-          // If we are at a vanity uri, we can't do a uri match
-          // The first search result _should_ be the same as the claim a user is on
-          if (atVanityURI) {
-            searchUris = searchUris.slice(1);
-          }
-
-          searchUris = searchUris.filter((searchUri) => searchUri !== uri);
+          searchUris = searchUris.filter((searchUri) => searchUri !== currentUri);
           recommendedContent = searchUris;
         }
       }


### PR DESCRIPTION
This is a much better solution to ensuring the same piece of content doesn't show up in related when you're at a vanity uri. We build the uri from the claim, then use that to filter against.