### PR TITLE
convert balance to number before saving

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -4106,7 +4106,9 @@ function doUpdateBalance() {
     var _getState = getState(),
         balanceInStore = _getState.wallet.balance;
 
-    _lbry2.default.account_balance().then(function (balance) {
+    _lbry2.default.account_balance().then(function (balanceAsString) {
+      var balance = parseFloat(balanceAsString);
+
       if (balanceInStore !== balance) {
         dispatch({
           type: ACTIONS.UPDATE_BALANCE,

--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -9,7 +9,9 @@ export function doUpdateBalance() {
     const {
       wallet: { balance: balanceInStore },
     } = getState();
-    Lbry.account_balance().then((balance) => {
+    Lbry.account_balance().then((balanceAsString) => {
+      const balance = parseFloat(balanceAsString);
+
       if (balanceInStore !== balance) {
         dispatch({
           type: ACTIONS.UPDATE_BALANCE,


### PR DESCRIPTION
Any place that checks the balance might be checking against a string currently, this makes sure it is always saved as a number.