### PR TITLE
fix: correctly show fees on tx's with no balance_delta or value (updates)

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -4573,14 +4573,16 @@ var selectTransactionItems = exports.selectTransactionItems = (0, _reselect.crea
     items.push.apply(items, _toConsumableArray(append.map(function (item) {
       // value on transaction, amount on outpoint
       // amount is always positive, but should match sign of value
-      var amount = parseFloat(item.balance_delta ? item.balance_delta : item.value);
+      var balanceDelta = parseFloat(item.balance_delta);
+      var value = parseFloat(item.value);
+      var amount = balanceDelta ? balanceDelta : value;
 
       return {
         txid: txid,
         timestamp: tx.timestamp,
         date: tx.timestamp ? new Date(Number(tx.timestamp) * 1000) : null,
         amount: amount,
-        fee: amount < 0 ? -1 * tx.fee / append.length : 0,
+        fee: amount <= 0 ? -1 * tx.fee / append.length : 0,
         claim_id: item.claim_id,
         claim_name: item.claim_name,
         type: item.type || TRANSACTIONS.SPEND,

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -4575,14 +4575,15 @@ var selectTransactionItems = exports.selectTransactionItems = (0, _reselect.crea
       // amount is always positive, but should match sign of value
       var balanceDelta = parseFloat(item.balance_delta);
       var value = parseFloat(item.value);
-      var amount = balanceDelta ? balanceDelta : value;
+      var amount = balanceDelta || value;
+      var fee = parseFloat(tx.fee);
 
       return {
         txid: txid,
         timestamp: tx.timestamp,
         date: tx.timestamp ? new Date(Number(tx.timestamp) * 1000) : null,
         amount: amount,
-        fee: amount <= 0 ? -1 * tx.fee / append.length : 0,
+        fee: fee,
         claim_id: item.claim_id,
         claim_name: item.claim_name,
         type: item.type || TRANSACTIONS.SPEND,

--- a/src/redux/selectors/wallet.js
+++ b/src/redux/selectors/wallet.js
@@ -130,13 +130,14 @@ export const selectTransactionItems = createSelector(selectTransactionsById, (by
         const balanceDelta = parseFloat(item.balance_delta);
         const value = parseFloat(item.value);
         const amount = balanceDelta || value;
+        const fee = parseFloat(tx.fee);
 
         return {
           txid,
           timestamp: tx.timestamp,
           date: tx.timestamp ? new Date(Number(tx.timestamp) * 1000) : null,
           amount,
-          fee: amount <= 0 ? -1 * tx.fee / append.length : 0,
+          fee,
           claim_id: item.claim_id,
           claim_name: item.claim_name,
           type: item.type || TRANSACTIONS.SPEND,

--- a/src/redux/selectors/wallet.js
+++ b/src/redux/selectors/wallet.js
@@ -127,14 +127,16 @@ export const selectTransactionItems = createSelector(selectTransactionsById, (by
       ...append.map((item) => {
         // value on transaction, amount on outpoint
         // amount is always positive, but should match sign of value
-        const amount = parseFloat(item.balance_delta ? item.balance_delta : item.value);
+        const balanceDelta = parseFloat(item.balance_delta);
+        const value = parseFloat(item.value);
+        const amount = balanceDelta || value;
 
         return {
           txid,
           timestamp: tx.timestamp,
           date: tx.timestamp ? new Date(Number(tx.timestamp) * 1000) : null,
           amount,
-          fee: amount < 0 ? -1 * tx.fee / append.length : 0,
+          fee: amount <= 0 ? -1 * tx.fee / append.length : 0,
           claim_id: item.claim_id,
           claim_name: item.claim_name,
           type: item.type || TRANSACTIONS.SPEND,


### PR DESCRIPTION
After some changes to how fees are sent in `transaction_list`, we need to change how we calculate the fee. Before this, updates were showing as 0 fee