### PR TITLE
change: utxo_release before transaction_list

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -4137,7 +4137,9 @@ function doFetchTransactions() {
       type: ACTIONS.FETCH_TRANSACTIONS_STARTED
     });
 
-    _lbry2.default.transaction_list().then(function (results) {
+    _lbry2.default.utxo_release().then(function () {
+      return _lbry2.default.transaction_list();
+    }).then(function (results) {
       dispatch({
         type: ACTIONS.FETCH_TRANSACTIONS_COMPLETED,
         data: {

--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -37,14 +37,16 @@ export function doFetchTransactions() {
       type: ACTIONS.FETCH_TRANSACTIONS_STARTED,
     });
 
-    Lbry.transaction_list().then((results) => {
-      dispatch({
-        type: ACTIONS.FETCH_TRANSACTIONS_COMPLETED,
-        data: {
-          transactions: results,
-        },
+    Lbry.utxo_release()
+      .then(() => Lbry.transaction_list())
+      .then((results) => {
+        dispatch({
+          type: ACTIONS.FETCH_TRANSACTIONS_COMPLETED,
+          data: {
+            transactions: results,
+          },
+        });
       });
-    });
   };
 }
 


### PR DESCRIPTION
https://github.com/lbryio/lbry/pull/1741/files#diff-96c4bef0747bf57a721011a7dfffa0a6R122

From Tom
> It's a quick call that resets any "reserved" transactions after a send. So it the send fails for some reason, this will help. Otherwise users would need to reset their blockchain.db file.