### PR TITLE
Search tweak

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -3409,7 +3409,7 @@ var selectSuggestions /*: (
   return state.suggestions;
 });
 
-var selectSearchQuery /*: (state: State) => ?string*/ = exports.selectSearchQuery = (0, _reselect.createSelector)(_navigation.selectCurrentPage, _navigation.selectCurrentParams, selectSearchValue, function (page /*: string*/, params /*: ?{ query: string }*/, searchValue) {
+var selectSearchQuery /*: (state: State) => ?string*/ = exports.selectSearchQuery = (0, _reselect.createSelector)(_navigation.selectCurrentPage, _navigation.selectCurrentParams, selectSearchValue, function (page /*: string*/, params /*: ?{ query: string }*/, searchValue /*: string*/) {
   return page === 'search' ? params && params.query : searchValue;
 });
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -3409,8 +3409,8 @@ var selectSuggestions /*: (
   return state.suggestions;
 });
 
-var selectSearchQuery /*: (state: State) => ?string*/ = exports.selectSearchQuery = (0, _reselect.createSelector)(_navigation.selectCurrentPage, _navigation.selectCurrentParams, function (page /*: string*/, params /*: ?{ query: string }*/) {
-  return page === 'search' ? params && params.query : null;
+var selectSearchQuery /*: (state: State) => ?string*/ = exports.selectSearchQuery = (0, _reselect.createSelector)(_navigation.selectCurrentPage, _navigation.selectCurrentParams, selectSearchValue, function (page /*: string*/, params /*: ?{ query: string }*/, searchValue) {
+  return page === 'search' ? params && params.query : searchValue;
 });
 
 var selectIsSearching /*: (state: State) => boolean*/ = exports.selectIsSearching = (0, _reselect.createSelector)(selectState, function (state) {

--- a/src/redux/selectors/search.js
+++ b/src/redux/selectors/search.js
@@ -31,7 +31,7 @@ export const selectSearchQuery: (state: State) => ?string = createSelector(
   selectCurrentPage,
   selectCurrentParams,
   selectSearchValue,
-  (page: string, params: ?{ query: string }, searchValue) =>
+  (page: string, params: ?{ query: string }, searchValue: string) =>
     page === 'search' ? params && params.query : searchValue
 );
 

--- a/src/redux/selectors/search.js
+++ b/src/redux/selectors/search.js
@@ -30,7 +30,9 @@ export const selectSuggestions: (
 export const selectSearchQuery: (state: State) => ?string = createSelector(
   selectCurrentPage,
   selectCurrentParams,
-  (page: string, params: ?{ query: string }) => (page === 'search' ? params && params.query : null)
+  selectSearchValue,
+  (page: string, params: ?{ query: string }, searchValue) =>
+    page === 'search' ? params && params.query : searchValue
 );
 
 export const selectIsSearching: (state: State) => boolean = createSelector(


### PR DESCRIPTION
@seanyesmunt This is a minor tweak to the `selectSearchQuery` selector to fallback to `selectSearchValue` since current page and the navigation params are not available for mobile. I'll merge it in, but if you have a better recommendation, please reopen and let me know. 