### PR TITLE
Allow unicode characters in claim names.

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -3766,6 +3766,7 @@ exports.notificationsReducer = notificationsReducer;
 exports.parseQueryParams = parseQueryParams;
 exports.parseURI = parseURI;
 exports.regexAddress = regexAddress;
+exports.regexInvalidURI = regexInvalidURI;
 exports.savePosition = savePosition;
 exports.searchReducer = searchReducer;
 exports.selectAbandoningIds = selectAbandoningIds;

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export {
 // common
 export { Lbry };
 export {
+  regexInvalidURI,
   regexAddress,
   parseURI,
   buildURI,

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -2,7 +2,7 @@ const channelNameMinLength = 1;
 const claimIdMaxLength = 40;
 
 // see https://spec.lbry.com/#urls
-const regexInvalidURI = (exports.regexInvalidURI = /[=&#:$@%?\u{0000}-\u{0008}\u{000b}-\u{000c}\u{000e}-\u{001F}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/gu);
+export const regexInvalidURI = (exports.regexInvalidURI = /[=&#:$@%?\u{0000}-\u{0008}\u{000b}-\u{000c}\u{000e}-\u{001F}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/gu);
 export const regexAddress = /^(b|r)(?=[^0OIl]{32,33})[0-9A-Za-z]{32,33}$/;
 
 /**

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -1,7 +1,8 @@
 const channelNameMinLength = 1;
 const claimIdMaxLength = 40;
 
-export const regexInvalidURI = /[^A-Za-z0-9-]/g;
+// see https://spec.lbry.com/#urls
+const regexInvalidURI = (exports.regexInvalidURI = /[=&#:$@%?\u{0000}-\u{0008}\u{000b}-\u{000c}\u{000e}-\u{001F}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/u);
 export const regexAddress = /^(b|r)(?=[^0OIl]{32,33})[0-9A-Za-z]{32,33}$/;
 
 /**


### PR DESCRIPTION
Regex created to spec at https://spec.lbry.com/#urls

Please note that this allows spaces and other control characters that exist beneath the ascii '!', like bells and linefeeds and whatnot. Not sure if you want this, but the spec BNF reads that way to me...

Test js I used after a `yarn build`:
```
lbryURI = require('./dist/bundle')
console.log(
    lbryURI.parseURI('The \u{1F680} Has Landed#917d741cbc652c1ba194dd7efd227f5c93c0bb4b')
    );
```