### PR TITLE
set main to bundle.es.js after removing webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "name": "LBRY Inc.",
     "email": "hello@lbry.io"
   },
-  "main": "dist/bundle.js",
+  "main": "dist/bundle.es.js",
   "module": "dist/bundle.es.js",
   "scripts": {
     "build": "rollup --config",


### PR DESCRIPTION
@seanyesmunt I'll merge this since it's a minor change. Since Webpack is no longer used and a `bundle.js` is no longer generated, I updated `main` in `package.json` to refer to `bundle.es.js` so that React Native would make use of that file instead. If this breaks anything else, please let me know. Thanks.