### PR TITLE
fix: remove mediaType when searching for files

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -775,10 +775,11 @@ const getSearchQueryString = (query, options = {}, includeUserOptions = false) =
   const queryParams = [`s=${encodedQuery}`, `size=${options.size || DEFAULT_SEARCH_SIZE}`, `from=${options.from || DEFAULT_SEARCH_RESULT_FROM}`];
 
   if (includeUserOptions) {
-    queryParams.push(`claimType=${options[SEARCH_OPTIONS.CLAIM_TYPE]}`);
+    const claimType = options[SEARCH_OPTIONS.CLAIM_TYPE];
+    queryParams.push(`claimType=${claimType}`);
 
     // If they are only searching for channels, strip out the media info
-    if (options[SEARCH_OPTIONS.CLAIM_TYPE] !== SEARCH_OPTIONS.INCLUDE_CHANNELS) {
+    if (!claimType.includes(SEARCH_OPTIONS.INCLUDE_CHANNELS)) {
       queryParams.push(`mediaType=${[SEARCH_OPTIONS.MEDIA_FILE, SEARCH_OPTIONS.MEDIA_AUDIO, SEARCH_OPTIONS.MEDIA_VIDEO, SEARCH_OPTIONS.MEDIA_TEXT, SEARCH_OPTIONS.MEDIA_IMAGE, SEARCH_OPTIONS.MEDIA_APPLICATION].reduce((acc, currentOption) => options[currentOption] ? `${acc}${currentOption},` : acc, '')}`);
     }
   }

--- a/src/util/query_params.js
+++ b/src/util/query_params.js
@@ -46,10 +46,11 @@ export const getSearchQueryString = (
   ];
 
   if (includeUserOptions) {
-    queryParams.push(`claimType=${options[SEARCH_OPTIONS.CLAIM_TYPE]}`);
+    const claimType = options[SEARCH_OPTIONS.CLAIM_TYPE];
+    queryParams.push(`claimType=${claimType}`);
 
     // If they are only searching for channels, strip out the media info
-    if (options[SEARCH_OPTIONS.CLAIM_TYPE] !== SEARCH_OPTIONS.INCLUDE_CHANNELS) {
+    if (!claimType.includes(SEARCH_OPTIONS.INCLUDE_CHANNELS)) {
       queryParams.push(
         `mediaType=${[
           SEARCH_OPTIONS.MEDIA_FILE,


### PR DESCRIPTION
Quick fix. 

Including `mediaType` in the same search query never returned channels.