### PR TITLE
Add comic book media-type detection

### DIFF
--- a/src/lbry.js
+++ b/src/lbry.js
@@ -31,6 +31,7 @@ const Lbry: LbryTypes = {
         [/^(mp3|m4a|aac|wav|flac|ogg|opus)$/i, 'audio'],
         [/^(html|htm|xml|pdf|odf|doc|docx|md|markdown|txt|epub|org)$/i, 'document'],
         [/^(stl|obj|fbx|gcode)$/i, '3D-file'],
+        [/^(cbr|cbz|cbt)$/i, 'comic-book'],
       ];
       const res = formats.reduce((ret, testpair) => {
         switch (testpair[0].test(ret)) {


### PR DESCRIPTION
> A comic book archive or comic book reader file (also called sequential image file) is a type of archive file for the purpose of sequential viewing of images, commonly for comic books.
https://en.wikipedia.org/wiki/Comic_book_archive

Required for https://github.com/lbryio/lbry-desktop/issues/1377