### PR TITLE
fix:  claim search

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2093,9 +2093,7 @@ function doFetchClaimsByChannel(uri, page = 1) {
       data: { uri, page }
     });
 
-    const { claimId } = parseURI(uri);
-
-    lbryProxy.claim_search({ channel_id: claimId, page: page || 1 }).then(result => {
+    lbryProxy.claim_search({ channel_name: uri, page: page || 1, winning: true }).then(result => {
       const { items: claimsInChannel, page: returnedPage } = result;
 
       dispatch({

--- a/src/redux/actions/claims.js
+++ b/src/redux/actions/claims.js
@@ -182,9 +182,7 @@ export function doFetchClaimsByChannel(uri: string, page: number = 1) {
       data: { uri, page },
     });
 
-    const { claimId } = parseURI(uri);
-
-    Lbry.claim_search({ channel_id: claimId, page: page || 1 }).then(
+    Lbry.claim_search({ channel_name: uri, page: page || 1, winning: true }).then(
       (result: ClaimSearchResponse) => {
         const { items: claimsInChannel, page: returnedPage } = result;
 


### PR DESCRIPTION
to use channel uri instead of claim id (support for vanity resolution)

I did not test this locally - would need to bring it into an Android build. The --winning parameter is required so that only the winning channel's claims are returned.