### PR TITLE
fix: controlling and channel claim count meta

### DIFF
--- a/dist/flow-typed/Claim.js
+++ b/dist/flow-typed/Claim.js
@@ -4,13 +4,13 @@ declare type Claim = StreamClaim | ChannelClaim;
 
 declare type ChannelClaim = GenericClaim & {
   is_channel_signature_valid?: boolean, // we may have signed channels in the future, fixes some flow issues for now.
-  signing_channel?: ChannelMetadata,
+  signing_channel?: ChannelClaim,
   value: ChannelMetadata,
 };
 
 declare type StreamClaim = GenericClaim & {
   is_channel_signature_valid?: boolean,
-  signing_channel?: ChannelMetadata,
+  signing_channel?: ChannelClaim,
   value: StreamMetadata,
 };
 

--- a/src/redux/actions/claims.js
+++ b/src/redux/actions/claims.js
@@ -64,7 +64,9 @@ export function doResolveUris(uris: Array<string>, returnCachedClaims: boolean =
               if (uriResolveInfo.signing_channel) {
                 result.channel = uriResolveInfo.signing_channel;
                 result.claimsInChannel =
-                  (uriResolveInfo.meta && uriResolveInfo.meta.claims_in_channel) || 0;
+                  (uriResolveInfo.signing_channel.meta &&
+                    uriResolveInfo.signing_channel.meta.claims_in_channel) ||
+                  0;
               }
             }
 
@@ -198,7 +200,7 @@ export function doFetchClaimsByChannel(uri: string, page: number = 1) {
 
     Lbry.claim_search({
       channel: uri,
-      is_controlling: true,
+      valid_channel_signatures: true,
       page: page || 1,
       order_by: ['release_time'],
     }).then((result: ClaimSearchResponse) => {


### PR DESCRIPTION
Controlling means controlling claims, not channels. Added so we only return claims with valid signatures (safer for now, can add options to show invalid later). Also, the claim count in channel is in the signed channel meta object, not the high level one.