### PR TITLE
fixes desktop compile error

### DIFF
--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -2,7 +2,7 @@ import * as ACTIONS from 'constants/action_types';
 import Lbry from 'lbry';
 import { doToast } from 'redux/actions/notifications';
 import { selectBalance } from 'redux/selectors/wallet';
-import { creditsToString } from 'util/formatCredits';
+import { creditsToString } from 'util/format-credits';
 import { selectMyClaimsRaw } from 'redux/selectors/claims';
 
 export function doUpdateBalance() {


### PR DESCRIPTION
looks like formatCredits was renamed to format-credits.js.
One in actions/wallet was not renamed.
This caused error on `yarn dev` on desktop.
```
ERROR in ../lbry-redux/dist/bundle.es.js
Module not found: Error: Can't resolve 'util/formatCredits' in '/home/jessop/git/vendor/LBRY/lbry-redux/dist'
 @ ../lbry-redux/dist/bundle.es.js 17:22-51
 @ ./src/platforms/electron/index.js
```
