### PR TITLE
fix: streaming + downloads

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2730,7 +2730,7 @@ function doPurchaseUri(uri, costInfo, saveFile = true, onSuccess) {
     const alreadyDownloading = fileInfo && !!downloadingByOutpoint[fileInfo.outpoint];
     const alreadyStreaming = makeSelectStreamingUrlForUri(uri)(state);
 
-    if (alreadyDownloading || alreadyStreaming) {
+    if (!saveFile && (alreadyDownloading || alreadyStreaming)) {
       dispatch({
         type: PURCHASE_URI_FAILED,
         data: { uri, error: `Already fetching uri: ${uri}` }

--- a/src/redux/actions/file.js
+++ b/src/redux/actions/file.js
@@ -95,7 +95,7 @@ export function doPurchaseUri(
     const alreadyDownloading = fileInfo && !!downloadingByOutpoint[fileInfo.outpoint];
     const alreadyStreaming = makeSelectStreamingUrlForUri(uri)(state);
 
-    if (alreadyDownloading || alreadyStreaming) {
+    if (!saveFile && (alreadyDownloading || alreadyStreaming)) {
       dispatch({
         type: ACTIONS.PURCHASE_URI_FAILED,
         data: { uri, error: `Already fetching uri: ${uri}` },


### PR DESCRIPTION
This goes along with the commit I made in your lbry-desktop branch. Allows you to download while streaming + re-download already streamed content if it was deleted or settings changed.