### PR TITLE
separates querystring

### DIFF
--- a/dist/flow-typed/Lbry.js
+++ b/dist/flow-typed/Lbry.js
@@ -66,7 +66,7 @@ declare type VersionResponse = {
 declare type BalanceResponse = {
   available: string,
   reserved: string,
-  reserved_subtotals: ? {
+  reserved_subtotals: ?{
     claims: string,
     supports: string,
     tips: string,
@@ -205,7 +205,7 @@ declare type LbryTypes = {
   comment_list: (params: {}) => Promise<CommentListResponse>,
   comment_create: (params: {}) => Promise<CommentCreateResponse>,
   // Wallet utilities
-  account_balance: (params: {}) => Promise<string>,
+  account_balance: (params: {}) => Promise<BalanceResponse>,
   account_decrypt: (prams: {}) => Promise<boolean>,
   account_encrypt: (params: {}) => Promise<boolean>,
   account_unlock: (params: {}) => Promise<boolean>,

--- a/dist/flow-typed/lbryURI.js
+++ b/dist/flow-typed/lbryURI.js
@@ -1,0 +1,20 @@
+// @flow
+declare type LbryUrlObj = {
+  // Path and channel will always exist when calling parseURI
+  // But they may not exist when code calls buildURI
+  isChannel?: boolean,
+  path?: string,
+  streamName?: string,
+  streamClaimId?: string,
+  channelName?: string,
+  channelClaimId?: string,
+  primaryClaimSequence?: number,
+  secondaryClaimSequence?: number,
+  primaryBidPosition?: number,
+  secondaryBidPosition?: number,
+
+  // Below are considered deprecated and should not be used due to unreliableness with claim.canonical_url
+  claimName?: string,
+  claimId?: string,
+  contentName?: string,
+};

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -9,6 +9,10 @@ export const regexAddress = /^(b|r)(?=[^0OIl]{32,33})[0-9A-Za-z]{32,33}$/;
 const regexPartProtocol = '^((?:lbry://)?)';
 const regexPartStreamOrChannelName = '([^:$#/]*)';
 const regexPartModifierSeparator = '([:$#]?)([^/]*)';
+const queryStringBreaker = '^([\\S]+)([?][\\S]*)';
+const separateQuerystring = new RegExp(
+  queryStringBreaker
+);
 
 /**
  * Parses a LBRY name into its component parts. Throws errors with user-friendly
@@ -29,6 +33,7 @@ const regexPartModifierSeparator = '([:$#]?)([^/]*)';
 
 export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj {
   // Break into components. Empty sub-matches are converted to null
+
   const componentsRegex = new RegExp(
     regexPartProtocol + // protocol
     regexPartStreamOrChannelName + // stream or channel name (stops at the first separator or end)
@@ -37,8 +42,15 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
       regexPartStreamOrChannelName +
       regexPartModifierSeparator
   );
+  // chop off the querystring first
+  let QSStrippedURL, qs;
+  const qsRegexResult = separateQuerystring.exec(URL)
+  if (qsRegexResult) {
+    [QSStrippedURL, qs] = qsRegexResult.slice(1).map(match => match || null);
+  }
 
-  const regexMatch = componentsRegex.exec(URL) || [];
+  const cleanURL = QSStrippedURL || URL;
+  const regexMatch = componentsRegex.exec(cleanURL) || [];
   const [proto, ...rest] = regexMatch.slice(1).map(match => match || null);
   const path = rest.join('');
   const [
@@ -114,6 +126,7 @@ function parseURIModifier(modSeperator: ?string, modValue: ?string) {
   let claimId;
   let claimSequence;
   let bidPosition;
+
   if (modSeperator) {
     if (!modValue) {
       throw new Error(__(`No modifier provided after separator %s.`, modSeperator));


### PR DESCRIPTION
forcepushed over.
now strips querystring at beginning of parseURL.