### PR TITLE
feat: granular balances

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,8 +91,6 @@ export { savePosition } from 'redux/actions/content';
 export {
   doUpdateBalance,
   doBalanceSubscribe,
-  doUpdateTotalBalance,
-  doTotalBalanceSubscribe,
   doFetchTransactions,
   doGetNewAddress,
   doCheckAddressIsMine,
@@ -258,6 +256,10 @@ export {
 export {
   selectBalance,
   selectTotalBalance,
+  selectReservedBalance,
+  selectClaimsBalance,
+  selectSupportsBalance,
+  selectTipsBalance,
   selectTransactionsById,
   selectSupportsByOutpoint,
   selectTotalSupports,

--- a/src/lbry.js
+++ b/src/lbry.js
@@ -93,7 +93,7 @@ const Lbry: LbryTypes = {
   blob_list: (params = {}) => daemonCallWithResult('blob_list', params),
 
   // Wallet utilities
-  account_balance: () => daemonCallWithResult('account_balance'),
+  account_balance: (params = {}) => daemonCallWithResult('account_balance', params),
   account_decrypt: () => daemonCallWithResult('account_decrypt', {}),
   account_encrypt: (params = {}) => daemonCallWithResult('account_encrypt', params),
   account_unlock: (params = {}) => daemonCallWithResult('account_unlock', params),

--- a/src/redux/reducers/wallet.js
+++ b/src/redux/reducers/wallet.js
@@ -16,6 +16,11 @@ type ActionResult = {
 
 type WalletState = {
   balance: any,
+  totalBalance: any,
+  reservedBalance: any,
+  claimsBalance: any,
+  supportsBalance: any,
+  tipsBalance: any,
   latestBlock: ?number,
   transactions: { [string]: Transaction },
   supports: { [string]: Support },
@@ -42,6 +47,10 @@ type WalletState = {
 const defaultState = {
   balance: undefined,
   totalBalance: undefined,
+  reservedBalance: undefined,
+  claimsBalance: undefined,
+  supportsBalance: undefined,
+  tipsBalance: undefined,
   latestBlock: undefined,
   transactions: {},
   fetchingTransactions: false,
@@ -146,12 +155,12 @@ export const walletReducer = handleActions(
 
     [ACTIONS.UPDATE_BALANCE]: (state: WalletState, action) => ({
       ...state,
-      balance: action.data.balance,
-    }),
-
-    [ACTIONS.UPDATE_TOTAL_BALANCE]: (state: WalletState, action) => ({
-      ...state,
       totalBalance: action.data.totalBalance,
+      balance: action.data.balance,
+      reservedBalance: action.data.reservedBalance,
+      claimsBalance: action.data.claimsBalance,
+      supportsBalance: action.data.supportsBalance,
+      tipsBalance: action.data.tipsBalance,
     }),
 
     [ACTIONS.CHECK_ADDRESS_IS_MINE_STARTED]: (state: WalletState) => ({

--- a/src/redux/selectors/wallet.js
+++ b/src/redux/selectors/wallet.js
@@ -80,6 +80,26 @@ export const selectTotalBalance = createSelector(
   state => state.totalBalance
 );
 
+export const selectReservedBalance = createSelector(
+  selectState,
+  state => state.reservedBalance
+);
+
+export const selectClaimsBalance = createSelector(
+  selectState,
+  state => state.claimsBalance
+);
+
+export const selectSupportsBalance = createSelector(
+  selectState,
+  state => state.supportsBalance
+);
+
+export const selectTipsBalance = createSelector(
+  selectState,
+  state => state.tipsBalance
+);
+
 export const selectTransactionsById = createSelector(
   selectState,
   state => state.transactions || {}


### PR DESCRIPTION
+ We were not using the total balances stuff I removed -that was an attempt by Akin at one point to work around the SDK cross account balance issue.
+ Decided to keep `balance` as is so we don't have to change it everywhere else...still makes sense I think.
