### PR TITLE
fix channel list reducer

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -3768,8 +3768,7 @@ reducers[FETCH_CHANNEL_LIST_COMPLETED] = (state, action) => {
   return Object.assign({}, state, {
     byId,
     fetchingMyChannels: false,
-    myChannelClaims,
-    myClaims: claims
+    myChannelClaims
   });
 };
 

--- a/src/redux/reducers/claims.js
+++ b/src/redux/reducers/claims.js
@@ -211,7 +211,6 @@ reducers[ACTIONS.FETCH_CHANNEL_LIST_COMPLETED] = (state: State, action: any): St
     byId,
     fetchingMyChannels: false,
     myChannelClaims,
-    myClaims: claims,
   });
 };
 


### PR DESCRIPTION
unsure if it is intentional but reducer for `FETCH_CHANNEL_LIST_COMPLETED` updates `myClaims` with an array of channel claims and removes other stream claims. this causes the related selectors (e.g. `makeSelectClaimIsMine`) produce wrong outputs after any calls to `doFetchChannelListMine`.