### PR TITLE
changes needed for preference sync

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -1470,7 +1470,7 @@ const buildSharedStateMiddleware = (actions, sharedStateFilters, sharedStateCb) 
 
     if (sharedStateCb) {
       // Pass dispatch to the callback to consumers can dispatch actions in response to preference set
-      sharedStateCb(dispatch);
+      sharedStateCb({ dispatch, getState });
     }
   }
 

--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2563,7 +2563,7 @@ function doUpdateChannel(params) {
       updateParams.tags = params.tags.map(tag => tag.name);
     }
 
-    //we'll need to remove these once we add locations/channels to channel page edit/create options
+    // we'll need to remove these once we add locations/channels to channel page edit/create options
 
     if (channelClaim && channelClaim.value && channelClaim.value.locations) {
       updateParams.locations = channelClaim.value.locations;
@@ -3834,7 +3834,12 @@ function doPreferenceSet(key, value, version, accountId, walletId, success, fail
     value
   };
 
-  lbryProxy.preference_set({ key, value: JSON.stringify(preference), account_id: accountId, wallet_id: walletId }).then(() => {
+  const options = _extends$5({
+    key,
+    value: JSON.stringify(preference)
+  }, accountId ? { account_id: accountId } : {}, walletId ? { wallet_id: walletId } : {});
+
+  lbryProxy.preference_set(options).then(() => {
     success(preference);
   }).catch(() => {
     if (fail) {
@@ -3844,7 +3849,11 @@ function doPreferenceSet(key, value, version, accountId, walletId, success, fail
 }
 
 function doPreferenceGet(key, accountId, walletId, success, fail) {
-  lbryProxy.preference_get({ key, account_id: accountId, wallet_id: walletId }).then(result => {
+  const options = _extends$5({
+    key
+  }, accountId ? { account_id: accountId } : {}, walletId ? { wallet_id: walletId } : {});
+
+  lbryProxy.preference_get(options).then(result => {
     if (result) {
       const preference = result[key];
       return success(preference);

--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -4803,7 +4803,7 @@ function getDefaultKnownTags() {
 }
 
 const defaultState$8 = {
-  followedTags: [],
+  followedTags: DEFAULT_FOLLOWED_TAGS,
   knownTags: getDefaultKnownTags()
 };
 

--- a/dist/flow-typed/Lbry.js
+++ b/dist/flow-typed/Lbry.js
@@ -210,12 +210,12 @@ declare type LbryTypes = {
   comment_list: (params: {}) => Promise<CommentListResponse>,
   comment_create: (params: {}) => Promise<CommentCreateResponse>,
   // Wallet utilities
-  account_balance: (params: {}) => Promise<BalanceResponse>,
+  wallet_balance: (params: {}) => Promise<BalanceResponse>,
   account_decrypt: (prams: {}) => Promise<boolean>,
   account_encrypt: (params: {}) => Promise<boolean>,
   account_unlock: (params: {}) => Promise<boolean>,
   account_list: (params: {}) => Promise<AccountListResponse>,
-  account_send: (params: {}) => Promise<GenericTxResponse>,
+  wallet_send: (params: {}) => Promise<GenericTxResponse>,
   account_set: (params: {}) => Promise<AccountSetResponse>,
   address_is_mine: (params: {}) => Promise<boolean>,
   address_unused: (params: {}) => Promise<string>, // New address

--- a/flow-typed/Lbry.js
+++ b/flow-typed/Lbry.js
@@ -210,12 +210,12 @@ declare type LbryTypes = {
   comment_list: (params: {}) => Promise<CommentListResponse>,
   comment_create: (params: {}) => Promise<CommentCreateResponse>,
   // Wallet utilities
-  account_balance: (params: {}) => Promise<BalanceResponse>,
+  wallet_balance: (params: {}) => Promise<BalanceResponse>,
   account_decrypt: (prams: {}) => Promise<boolean>,
   account_encrypt: (params: {}) => Promise<boolean>,
   account_unlock: (params: {}) => Promise<boolean>,
   account_list: (params: {}) => Promise<AccountListResponse>,
-  account_send: (params: {}) => Promise<GenericTxResponse>,
+  wallet_send: (params: {}) => Promise<GenericTxResponse>,
   account_set: (params: {}) => Promise<AccountSetResponse>,
   address_is_mine: (params: {}) => Promise<boolean>,
   address_unused: (params: {}) => Promise<string>, // New address

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,9 @@ export {
   convertToShareLink,
 } from 'lbryURI';
 
+// middlware
+export { buildSharedStateMiddleware } from 'redux/middleware/shared-state';
+
 // actions
 export { doToast, doDismissToast, doError, doDismissError } from 'redux/actions/notifications';
 
@@ -114,12 +117,7 @@ export { doCommentList, doCommentCreate } from 'redux/actions/comments';
 
 export { doToggleBlockChannel } from 'redux/actions/blocked';
 
-export {
-  doPopulateSharedUserState,
-  doPreferenceGet,
-  doPreferenceSet,
-  sharedStateSubscriber
-} from 'redux/actions/sync';
+export { doPopulateSharedUserState, doPreferenceGet, doPreferenceSet } from 'redux/actions/sync';
 
 // utils
 export { batchActions } from 'util/batch-actions';

--- a/src/lbry.js
+++ b/src/lbry.js
@@ -93,12 +93,12 @@ const Lbry: LbryTypes = {
   blob_list: (params = {}) => daemonCallWithResult('blob_list', params),
 
   // Wallet utilities
-  account_balance: (params = {}) => daemonCallWithResult('account_balance', params),
+  wallet_balance: (params = {}) => daemonCallWithResult('wallet_balance', params),
   account_decrypt: () => daemonCallWithResult('account_decrypt', {}),
   account_encrypt: (params = {}) => daemonCallWithResult('account_encrypt', params),
   account_unlock: (params = {}) => daemonCallWithResult('account_unlock', params),
   account_list: (params = {}) => daemonCallWithResult('account_list', params),
-  account_send: (params = {}) => daemonCallWithResult('account_send', params),
+  wallet_send: (params = {}) => daemonCallWithResult('wallet_send', params),
   account_set: (params = {}) => daemonCallWithResult('account_set', params),
   address_is_mine: (params = {}) => daemonCallWithResult('address_is_mine', params),
   address_unused: (params = {}) => daemonCallWithResult('address_unused', params),

--- a/src/redux/actions/sync.js
+++ b/src/redux/actions/sync.js
@@ -39,8 +39,8 @@ export function sharedStateSubscriber(
   filters: any,
   version: string,
   accountId: string,
-  walletId: string)
-{
+  walletId: string
+) {
   // the shared object that will be saved
   const shared = {};
 
@@ -54,7 +54,6 @@ export function sharedStateSubscriber(
 
     shared[key] = value;
   });
-
 
   if (!isEqual(oldShared, shared)) {
     // only update if the preference changed from last call in the same session
@@ -73,33 +72,54 @@ export function doPreferenceSet(
   fail: Function
 ) {
   const preference = {
-    type: (typeof value),
+    type: typeof value,
     version,
     value,
   };
 
-  Lbry.preference_set({ key, value: JSON.stringify(preference), account_id: accountId, wallet_id: walletId }).then(() => {
-    success(preference);
-  }).catch(() => {
-    if (fail) { fail(); }
-  });
+  const options = {
+    key,
+    value: JSON.stringify(preference),
+    ...(accountId ? { account_id: accountId } : {}),
+    ...(walletId ? { wallet_id: walletId } : {}),
+  };
+
+  Lbry.preference_set(options)
+    .then(() => {
+      success(preference);
+    })
+    .catch(() => {
+      if (fail) {
+        fail();
+      }
+    });
 }
 
 export function doPreferenceGet(
   key: string,
-  accountId: string,
-  walletId: string,
+  accountId?: string,
+  walletId?: string,
   success: Function,
-  fail: Function
+  fail?: Function
 ) {
-  Lbry.preference_get({ key, account_id: accountId, wallet_id: walletId }).then(result => {
-    if (result) {
-      const preference = result[key];
-      return success(preference);
-    }
+  const options = {
+    key,
+    ...(accountId ? { account_id: accountId } : {}),
+    ...(walletId ? { wallet_id: walletId } : {}),
+  };
 
-    return success(null);
-  }).catch(err => {
-    if (fail) { fail(err); }
-  });
+  Lbry.preference_get(options)
+    .then(result => {
+      if (result) {
+        const preference = result[key];
+        return success(preference);
+      }
+
+      return success(null);
+    })
+    .catch(err => {
+      if (fail) {
+        fail(err);
+      }
+    });
 }

--- a/src/redux/actions/sync.js
+++ b/src/redux/actions/sync.js
@@ -1,26 +1,24 @@
 // @flow
 import * as ACTIONS from 'constants/action_types';
 import Lbry from 'lbry';
-import isEqual from 'util/deep-equal';
 
-type sharedData = {
+type SharedData = {
   version: '0.1',
   value: {
     subscriptions?: Array<string>,
     tags?: Array<string>,
+    blockedChannels?: Array<string>,
   },
 };
 
-let oldShared;
-const sharedPreferenceKey = 'shared';
-
-function extractUserState(rawObj: sharedData) {
+function extractUserState(rawObj: SharedData) {
   if (rawObj && rawObj.version === '0.1' && rawObj.value) {
-    const { subscriptions, tags } = rawObj.value;
+    const { subscriptions, tags, blockedChannels } = rawObj.value;
 
     return {
       ...(subscriptions ? { subscriptions } : {}),
       ...(tags ? { tags } : {}),
+      ...(blockedChannels ? { blockedChannels } : {}),
     };
   }
 
@@ -34,40 +32,10 @@ export function doPopulateSharedUserState(settings: any) {
   };
 }
 
-export function sharedStateSubscriber(
-  state: any,
-  filters: any,
-  version: string,
-  accountId: string,
-  walletId: string
-) {
-  // the shared object that will be saved
-  const shared = {};
-
-  Object.keys(filters).forEach(key => {
-    const filter = filters[key];
-    const { source, property, transform } = filter;
-    let value = state[source][property];
-    if (transform) {
-      value = transform(value);
-    }
-
-    shared[key] = value;
-  });
-
-  if (!isEqual(oldShared, shared)) {
-    // only update if the preference changed from last call in the same session
-    oldShared = shared;
-    doPreferenceSet(sharedPreferenceKey, shared, version, accountId, walletId);
-  }
-}
-
 export function doPreferenceSet(
   key: string,
   value: any,
   version: string,
-  accountId: string,
-  walletId: string,
   success: Function,
   fail: Function
 ) {
@@ -80,8 +48,6 @@ export function doPreferenceSet(
   const options = {
     key,
     value: JSON.stringify(preference),
-    ...(accountId ? { account_id: accountId } : {}),
-    ...(walletId ? { wallet_id: walletId } : {}),
   };
 
   Lbry.preference_set(options)
@@ -95,17 +61,9 @@ export function doPreferenceSet(
     });
 }
 
-export function doPreferenceGet(
-  key: string,
-  accountId?: string,
-  walletId?: string,
-  success: Function,
-  fail?: Function
-) {
+export function doPreferenceGet(key: string, success: Function, fail?: Function) {
   const options = {
     key,
-    ...(accountId ? { account_id: accountId } : {}),
-    ...(walletId ? { wallet_id: walletId } : {}),
   };
 
   Lbry.preference_get(options)

--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -10,7 +10,7 @@ export function doUpdateBalance() {
     const {
       wallet: { totalBalance: totalInStore },
     } = getState();
-    return Lbry.account_balance({ reserved_subtotals: true }).then((response: BalanceResponse) => {
+    return Lbry.wallet_balance({ reserved_subtotals: true }).then(response => {
       const { available, reserved, reserved_subtotals, total } = response;
       const { claims, supports, tips } = reserved_subtotals;
       const totalFloat = parseFloat(total);
@@ -165,7 +165,7 @@ export function doSendDraftTransaction(address, amount) {
       );
     };
 
-    Lbry.account_send({
+    Lbry.wallet_send({
       addresses: [address],
       amount: creditsToString(amount),
     }).then(successCallback, errorCallback);

--- a/src/redux/middleware/shared-state.js
+++ b/src/redux/middleware/shared-state.js
@@ -43,7 +43,7 @@ export const buildSharedStateMiddleware = (
 
     if (sharedStateCb) {
       // Pass dispatch to the callback to consumers can dispatch actions in response to preference set
-      sharedStateCb(dispatch);
+      sharedStateCb({ dispatch, getState });
     }
   }
 

--- a/src/redux/middleware/shared-state.js
+++ b/src/redux/middleware/shared-state.js
@@ -1,0 +1,51 @@
+// @flow
+import isEqual from 'util/deep-equal';
+import { doPreferenceSet } from 'redux/actions/sync';
+
+const SHARED_PREFERENCE_KEY = 'shared';
+const SHARED_PREFERENCE_VERSION = '0.1';
+let oldShared = {};
+
+export const buildSharedStateMiddleware = (
+  actions: Array<string>,
+  sharedStateFilters: {},
+  sharedStateCb?: any => void
+) => ({ getState, dispatch }: { getState: () => {}, dispatch: any => void }) => (
+  next: ({}) => void
+) => (action: { type: string, data: any }) => {
+  const currentState = getState();
+
+  // We don't care if sync is disabled here, we always want to backup preferences to the wallet
+  if (!actions.includes(action.type)) {
+    return next(action);
+  }
+
+  const actionResult = next(action);
+  // Call `getState` after calling `next` to ensure the state has updated in response to the action
+  const nextState = getState();
+  const shared = {};
+
+  Object.keys(sharedStateFilters).forEach(key => {
+    const filter = sharedStateFilters[key];
+    const { source, property, transform } = filter;
+    let value = nextState[source][property];
+    if (transform) {
+      value = transform(value);
+    }
+
+    shared[key] = value;
+  });
+
+  if (!isEqual(oldShared, shared)) {
+    // only update if the preference changed from last call in the same session
+    oldShared = shared;
+    doPreferenceSet(SHARED_PREFERENCE_KEY, shared, SHARED_PREFERENCE_VERSION);
+
+    if (sharedStateCb) {
+      // Pass dispatch to the callback to consumers can dispatch actions in response to preference set
+      sharedStateCb(dispatch);
+    }
+  }
+
+  return actionResult;
+};

--- a/src/redux/reducers/blocked.js
+++ b/src/redux/reducers/blocked.js
@@ -26,6 +26,17 @@ export const blockedReducer = handleActions(
         blockedChannels: newBlockedChannels,
       };
     },
+    [ACTIONS.USER_STATE_POPULATE]: (
+      state: BlocklistState,
+      action: { data: { blockedChannels: ?Array<string> } }
+    ) => {
+      const { blockedChannels } = action.data;
+      return {
+        ...state,
+        blockedChannels:
+          blockedChannels && blockedChannels.length ? blockedChannels : state.blockedChannels,
+      };
+    },
   },
   defaultState
 );

--- a/src/redux/reducers/tags.js
+++ b/src/redux/reducers/tags.js
@@ -14,7 +14,7 @@ function getDefaultKnownTags() {
 }
 
 const defaultState: TagState = {
-  followedTags: [],
+  followedTags: DEFAULT_FOLLOWED_TAGS,
   knownTags: getDefaultKnownTags(),
 };
 


### PR DESCRIPTION
- now using middleware to handle calling `preference_set`
- changed ACCOUNT_XXX to WALLET_XXX
  - There are still more redux changes for the wallet commands but those can be addressed later
- Removed `accountId`, and `walletId` params since they aren't being used anywhere.