### PR TITLE
fix: pass mediaType query param to search if 'everything' is selected

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -15,6 +15,7 @@ const CHANNEL_NEW = 'new';
 const PAGE_SIZE = 20;
 
 var claim = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   MINIMUM_PUBLISH_BID: MINIMUM_PUBLISH_BID,
   CHANNEL_ANONYMOUS: CHANNEL_ANONYMOUS,
   CHANNEL_NEW: CHANNEL_NEW,
@@ -269,6 +270,7 @@ const TOGGLE_BLOCK_CHANNEL = 'TOGGLE_BLOCK_CHANNEL';
 const USER_STATE_POPULATE = 'USER_STATE_POPULATE';
 
 var action_types = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   WINDOW_FOCUSED: WINDOW_FOCUSED,
   DAEMON_READY: DAEMON_READY,
   DAEMON_VERSION_MATCH: DAEMON_VERSION_MATCH,
@@ -506,6 +508,7 @@ const OTHER = 'other';
 const COPYRIGHT = 'copyright';
 
 var licenses = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   CC_LICENSES: CC_LICENSES,
   NONE: NONE,
   PUBLIC_DOMAIN: PUBLIC_DOMAIN,
@@ -536,6 +539,7 @@ const HISTORY = 'user_history';
 const WALLET = 'wallet';
 
 var pages = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   AUTH: AUTH,
   BACKUP: BACKUP,
   CHANNEL: CHANNEL,
@@ -585,6 +589,7 @@ const RECEIVE_INTERESTS_NOTIFICATIONS = 'receiveInterestsNotifications';
 const RECEIVE_CREATOR_NOTIFICATIONS = 'receiveCreatorNotifications';
 
 var settings = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   CREDIT_REQUIRED_ACKNOWLEDGED: CREDIT_REQUIRED_ACKNOWLEDGED,
   NEW_USER_ACKNOWLEDGED: NEW_USER_ACKNOWLEDGED,
   EMAIL_COLLECTION_ACKNOWLEDGED: EMAIL_COLLECTION_ACKNOWLEDGED,
@@ -612,6 +617,7 @@ const TITLE = 'title';
 const FILENAME = 'filename';
 
 var sort_options = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   DATE_NEW: DATE_NEW,
   DATE_OLD: DATE_OLD,
   TITLE: TITLE,
@@ -625,6 +631,7 @@ const COMPLETE = 'complete';
 const MANUAL = 'manual';
 
 var thumbnail_upload_statuses = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   API_DOWN: API_DOWN,
   READY: READY,
   IN_PROGRESS: IN_PROGRESS,
@@ -644,6 +651,7 @@ const UPDATE = 'update';
 const ABANDON = 'abandon';
 
 var transaction_types = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   ALL: ALL,
   SPEND: SPEND,
   RECEIVE: RECEIVE,
@@ -660,6 +668,7 @@ const PAGE_SIZE$1 = 50;
 const LATEST_PAGE_SIZE = 20;
 
 var transaction_list = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   PAGE_SIZE: PAGE_SIZE$1,
   LATEST_PAGE_SIZE: LATEST_PAGE_SIZE
 });
@@ -668,6 +677,7 @@ const SPEECH_STATUS = 'https://spee.ch/api/config/site/publishing';
 const SPEECH_PUBLISH = 'https://spee.ch/api/claim/publish';
 
 var speech_urls = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   SPEECH_STATUS: SPEECH_STATUS,
   SPEECH_PUBLISH: SPEECH_PUBLISH
 });
@@ -944,7 +954,7 @@ const getSearchQueryString = (query, options = {}, includeUserOptions = false) =
     queryParams.push(`claimType=${claimType}`);
 
     // If they are only searching for channels, strip out the media info
-    if (!claimType.includes(SEARCH_OPTIONS.INCLUDE_CHANNELS)) {
+    if (claimType !== SEARCH_OPTIONS.INCLUDE_CHANNELS) {
       queryParams.push(`mediaType=${[SEARCH_OPTIONS.MEDIA_FILE, SEARCH_OPTIONS.MEDIA_AUDIO, SEARCH_OPTIONS.MEDIA_VIDEO, SEARCH_OPTIONS.MEDIA_TEXT, SEARCH_OPTIONS.MEDIA_IMAGE, SEARCH_OPTIONS.MEDIA_APPLICATION].reduce((acc, currentOption) => options[currentOption] ? `${acc}${currentOption},` : acc, '')}`);
     }
   }

--- a/src/util/query-params.js
+++ b/src/util/query-params.js
@@ -50,7 +50,7 @@ export const getSearchQueryString = (
     queryParams.push(`claimType=${claimType}`);
 
     // If they are only searching for channels, strip out the media info
-    if (!claimType.includes(SEARCH_OPTIONS.INCLUDE_CHANNELS)) {
+    if (claimType !== SEARCH_OPTIONS.INCLUDE_CHANNELS) {
       queryParams.push(
         `mediaType=${[
           SEARCH_OPTIONS.MEDIA_FILE,


### PR DESCRIPTION
We weren't passing `mediaType` to search if channels were inlcuded in the claimType. i think this might have been because of a lighthouse issue?