### PR TITLE
pass related_to flag to search for recommended content

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2202,7 +2202,7 @@ const makeSelectRecommendedContentForUri = uri => reselect.createSelector(makeSe
       return;
     }
 
-    const searchQuery = getSearchQueryString(title, undefined, undefined, {
+    const searchQuery = getSearchQueryString(title.replace(/\//, ' '), undefined, undefined, {
       related_to: claim.claim_id
     });
 

--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -15,7 +15,6 @@ const CHANNEL_NEW = 'new';
 const PAGE_SIZE = 20;
 
 var claim = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   MINIMUM_PUBLISH_BID: MINIMUM_PUBLISH_BID,
   CHANNEL_ANONYMOUS: CHANNEL_ANONYMOUS,
   CHANNEL_NEW: CHANNEL_NEW,
@@ -275,7 +274,6 @@ const TOGGLE_BLOCK_CHANNEL = 'TOGGLE_BLOCK_CHANNEL';
 const USER_STATE_POPULATE = 'USER_STATE_POPULATE';
 
 var action_types = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   WINDOW_FOCUSED: WINDOW_FOCUSED,
   DAEMON_READY: DAEMON_READY,
   DAEMON_VERSION_MATCH: DAEMON_VERSION_MATCH,
@@ -518,7 +516,6 @@ const OTHER = 'other';
 const COPYRIGHT = 'copyright';
 
 var licenses = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   CC_LICENSES: CC_LICENSES,
   NONE: NONE,
   PUBLIC_DOMAIN: PUBLIC_DOMAIN,
@@ -549,7 +546,6 @@ const HISTORY = 'user_history';
 const WALLET = 'wallet';
 
 var pages = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   AUTH: AUTH,
   BACKUP: BACKUP,
   CHANNEL: CHANNEL,
@@ -599,7 +595,6 @@ const RECEIVE_INTERESTS_NOTIFICATIONS = 'receiveInterestsNotifications';
 const RECEIVE_CREATOR_NOTIFICATIONS = 'receiveCreatorNotifications';
 
 var settings = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   CREDIT_REQUIRED_ACKNOWLEDGED: CREDIT_REQUIRED_ACKNOWLEDGED,
   NEW_USER_ACKNOWLEDGED: NEW_USER_ACKNOWLEDGED,
   EMAIL_COLLECTION_ACKNOWLEDGED: EMAIL_COLLECTION_ACKNOWLEDGED,
@@ -627,7 +622,6 @@ const TITLE = 'title';
 const FILENAME = 'filename';
 
 var sort_options = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   DATE_NEW: DATE_NEW,
   DATE_OLD: DATE_OLD,
   TITLE: TITLE,
@@ -641,7 +635,6 @@ const COMPLETE = 'complete';
 const MANUAL = 'manual';
 
 var thumbnail_upload_statuses = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   API_DOWN: API_DOWN,
   READY: READY,
   IN_PROGRESS: IN_PROGRESS,
@@ -661,7 +654,6 @@ const UPDATE = 'update';
 const ABANDON = 'abandon';
 
 var transaction_types = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   ALL: ALL,
   SPEND: SPEND,
   RECEIVE: RECEIVE,
@@ -678,7 +670,6 @@ const PAGE_SIZE$1 = 50;
 const LATEST_PAGE_SIZE = 20;
 
 var transaction_list = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   PAGE_SIZE: PAGE_SIZE$1,
   LATEST_PAGE_SIZE: LATEST_PAGE_SIZE
 });
@@ -687,7 +678,6 @@ const SPEECH_STATUS = 'https://spee.ch/api/config/site/publishing';
 const SPEECH_PUBLISH = 'https://spee.ch/api/claim/publish';
 
 var speech_urls = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   SPEECH_STATUS: SPEECH_STATUS,
   SPEECH_PUBLISH: SPEECH_PUBLISH
 });
@@ -733,7 +723,6 @@ const WALLET_DIR = 'wallet_dir';
 const WALLETS = 'wallets';
 
 var daemon_settings = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   ANNOUNCE_HEAD_AND_SD_ONLY: ANNOUNCE_HEAD_AND_SD_ONLY,
   API: API,
   BLOB_DOWNLOAD_TIMEOUT: BLOB_DOWNLOAD_TIMEOUT,
@@ -787,7 +776,6 @@ var daemon_settings = /*#__PURE__*/Object.freeze({
 const WALLET_SERVERS = LBRYUM_SERVERS;
 
 var shared_preferences = /*#__PURE__*/Object.freeze({
-  __proto__: null,
   WALLET_SERVERS: WALLET_SERVERS
 });
 
@@ -1133,17 +1121,17 @@ function parseURI(URL, requireProto = false) {
 
   // Validate protocol
   if (requireProto && !proto) {
-    throw new Error(__('LBRY URLs must include a protocol prefix (lbry://).'));
+    console.error(__('LBRY URLs must include a protocol prefix (lbry://).'));
   }
 
   // Validate and process name
   if (!streamNameOrChannelName) {
-    throw new Error(__('URL does not include name.'));
+    console.error(__('URL does not include name.'));
   }
 
   rest.forEach(urlPiece => {
     if (urlPiece && urlPiece.includes(' ')) {
-      throw new Error('URL can not include a space');
+      console.error('URL can not include a space');
     }
   });
 
@@ -1153,11 +1141,11 @@ function parseURI(URL, requireProto = false) {
 
   if (includesChannel) {
     if (!channelName) {
-      throw new Error(__('No channel name after @.'));
+      console.error(__('No channel name after @.'));
     }
 
     if (channelName.length < channelNameMinLength) {
-      throw new Error(__(`Channel names must be at least %channelNameMinLength% characters.`, {
+      console.error(__(`Channel names must be at least %channelNameMinLength% characters.`, {
         channelNameMinLength
       }));
     }

--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -15,6 +15,7 @@ const CHANNEL_NEW = 'new';
 const PAGE_SIZE = 20;
 
 var claim = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   MINIMUM_PUBLISH_BID: MINIMUM_PUBLISH_BID,
   CHANNEL_ANONYMOUS: CHANNEL_ANONYMOUS,
   CHANNEL_NEW: CHANNEL_NEW,
@@ -274,6 +275,7 @@ const TOGGLE_BLOCK_CHANNEL = 'TOGGLE_BLOCK_CHANNEL';
 const USER_STATE_POPULATE = 'USER_STATE_POPULATE';
 
 var action_types = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   WINDOW_FOCUSED: WINDOW_FOCUSED,
   DAEMON_READY: DAEMON_READY,
   DAEMON_VERSION_MATCH: DAEMON_VERSION_MATCH,
@@ -516,6 +518,7 @@ const OTHER = 'other';
 const COPYRIGHT = 'copyright';
 
 var licenses = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   CC_LICENSES: CC_LICENSES,
   NONE: NONE,
   PUBLIC_DOMAIN: PUBLIC_DOMAIN,
@@ -546,6 +549,7 @@ const HISTORY = 'user_history';
 const WALLET = 'wallet';
 
 var pages = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   AUTH: AUTH,
   BACKUP: BACKUP,
   CHANNEL: CHANNEL,
@@ -595,6 +599,7 @@ const RECEIVE_INTERESTS_NOTIFICATIONS = 'receiveInterestsNotifications';
 const RECEIVE_CREATOR_NOTIFICATIONS = 'receiveCreatorNotifications';
 
 var settings = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   CREDIT_REQUIRED_ACKNOWLEDGED: CREDIT_REQUIRED_ACKNOWLEDGED,
   NEW_USER_ACKNOWLEDGED: NEW_USER_ACKNOWLEDGED,
   EMAIL_COLLECTION_ACKNOWLEDGED: EMAIL_COLLECTION_ACKNOWLEDGED,
@@ -622,6 +627,7 @@ const TITLE = 'title';
 const FILENAME = 'filename';
 
 var sort_options = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   DATE_NEW: DATE_NEW,
   DATE_OLD: DATE_OLD,
   TITLE: TITLE,
@@ -635,6 +641,7 @@ const COMPLETE = 'complete';
 const MANUAL = 'manual';
 
 var thumbnail_upload_statuses = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   API_DOWN: API_DOWN,
   READY: READY,
   IN_PROGRESS: IN_PROGRESS,
@@ -654,6 +661,7 @@ const UPDATE = 'update';
 const ABANDON = 'abandon';
 
 var transaction_types = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   ALL: ALL,
   SPEND: SPEND,
   RECEIVE: RECEIVE,
@@ -670,6 +678,7 @@ const PAGE_SIZE$1 = 50;
 const LATEST_PAGE_SIZE = 20;
 
 var transaction_list = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   PAGE_SIZE: PAGE_SIZE$1,
   LATEST_PAGE_SIZE: LATEST_PAGE_SIZE
 });
@@ -678,6 +687,7 @@ const SPEECH_STATUS = 'https://spee.ch/api/config/site/publishing';
 const SPEECH_PUBLISH = 'https://spee.ch/api/claim/publish';
 
 var speech_urls = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   SPEECH_STATUS: SPEECH_STATUS,
   SPEECH_PUBLISH: SPEECH_PUBLISH
 });
@@ -723,6 +733,7 @@ const WALLET_DIR = 'wallet_dir';
 const WALLETS = 'wallets';
 
 var daemon_settings = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   ANNOUNCE_HEAD_AND_SD_ONLY: ANNOUNCE_HEAD_AND_SD_ONLY,
   API: API,
   BLOB_DOWNLOAD_TIMEOUT: BLOB_DOWNLOAD_TIMEOUT,
@@ -776,6 +787,7 @@ var daemon_settings = /*#__PURE__*/Object.freeze({
 const WALLET_SERVERS = LBRYUM_SERVERS;
 
 var shared_preferences = /*#__PURE__*/Object.freeze({
+  __proto__: null,
   WALLET_SERVERS: WALLET_SERVERS
 });
 
@@ -2352,6 +2364,8 @@ function doUpdateBalance() {
             }
           });
         }
+      }).catch(() => {
+        walletBalancePromise = null;
       });
     }
 

--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -1121,12 +1121,12 @@ function parseURI(URL, requireProto = false) {
 
   // Validate protocol
   if (requireProto && !proto) {
-    console.error(__('LBRY URLs must include a protocol prefix (lbry://).'));
+    throw new Error(__('LBRY URLs must include a protocol prefix (lbry://).'));
   }
 
   // Validate and process name
   if (!streamNameOrChannelName) {
-    console.error(__('URL does not include name.'));
+    throw new Error(__('URL does not include name.'));
   }
 
   rest.forEach(urlPiece => {
@@ -1141,11 +1141,11 @@ function parseURI(URL, requireProto = false) {
 
   if (includesChannel) {
     if (!channelName) {
-      console.error(__('No channel name after @.'));
+      throw new Error(__('No channel name after @.'));
     }
 
     if (channelName.length < channelNameMinLength) {
-      console.error(__(`Channel names must be at least %channelNameMinLength% characters.`, {
+      throw new Error(__(`Channel names must be at least %channelNameMinLength% characters.`, {
         channelNameMinLength
       }));
     }
@@ -1177,7 +1177,7 @@ function parseURIModifier(modSeperator, modValue) {
 
   if (modSeperator) {
     if (!modValue) {
-      console.error(__(`No modifier provided after separator %modSeperator%.`, { modSeperator }));
+      throw new Error(__(`No modifier provided after separator %modSeperator%.`, { modSeperator }));
     }
 
     if (modSeperator === '#') {
@@ -1190,15 +1190,15 @@ function parseURIModifier(modSeperator, modValue) {
   }
 
   if (claimId && (claimId.length > claimIdMaxLength || !claimId.match(/^[0-9a-f]+$/))) {
-    console.error(__(`Invalid claim ID %claimId%.`, { claimId }));
+    throw new Error(__(`Invalid claim ID %claimId%.`, { claimId }));
   }
 
   if (claimSequence && !claimSequence.match(/^-?[1-9][0-9]*$/)) {
-    console.error(__('Claim sequence must be a number.'));
+    throw new Error(__('Claim sequence must be a number.'));
   }
 
   if (bidPosition && !bidPosition.match(/^-?[1-9][0-9]*$/)) {
-    console.error(__('Bid position must be a number.'));
+    throw new Error(__('Bid position must be a number.'));
   }
 
   return [claimId, claimSequence, bidPosition];

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -63,17 +63,17 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
 
   // Validate protocol
   if (requireProto && !proto) {
-    throw new Error(__('LBRY URLs must include a protocol prefix (lbry://).'));
+    console.error(__('LBRY URLs must include a protocol prefix (lbry://).'));
   }
 
   // Validate and process name
   if (!streamNameOrChannelName) {
-    throw new Error(__('URL does not include name.'));
+    console.error(__('URL does not include name.'));
   }
 
   rest.forEach(urlPiece => {
     if (urlPiece && urlPiece.includes(' ')) {
-      throw new Error('URL can not include a space');
+      console.error('URL can not include a space');
     }
   });
 
@@ -83,11 +83,11 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
 
   if (includesChannel) {
     if (!channelName) {
-      throw new Error(__('No channel name after @.'));
+      console.error(__('No channel name after @.'));
     }
 
     if (channelName.length < channelNameMinLength) {
-      throw new Error(
+      console.error(
         __(`Channel names must be at least %channelNameMinLength% characters.`, {
           channelNameMinLength,
         })

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -63,12 +63,12 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
 
   // Validate protocol
   if (requireProto && !proto) {
-    console.error(__('LBRY URLs must include a protocol prefix (lbry://).'));
+    throw new Error(__('LBRY URLs must include a protocol prefix (lbry://).'));
   }
 
   // Validate and process name
   if (!streamNameOrChannelName) {
-    console.error(__('URL does not include name.'));
+    throw new Error(__('URL does not include name.'));
   }
 
   rest.forEach(urlPiece => {
@@ -83,11 +83,11 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
 
   if (includesChannel) {
     if (!channelName) {
-      console.error(__('No channel name after @.'));
+      throw new Error(__('No channel name after @.'));
     }
 
     if (channelName.length < channelNameMinLength) {
-      console.error(
+      throw new Error(
         __(`Channel names must be at least %channelNameMinLength% characters.`, {
           channelNameMinLength,
         })
@@ -138,7 +138,7 @@ function parseURIModifier(modSeperator: ?string, modValue: ?string) {
 
   if (modSeperator) {
     if (!modValue) {
-      console.error(__(`No modifier provided after separator %modSeperator%.`, { modSeperator }));
+      throw new Error(__(`No modifier provided after separator %modSeperator%.`, { modSeperator }));
     }
 
     if (modSeperator === '#') {
@@ -151,15 +151,15 @@ function parseURIModifier(modSeperator: ?string, modValue: ?string) {
   }
 
   if (claimId && (claimId.length > claimIdMaxLength || !claimId.match(/^[0-9a-f]+$/))) {
-    console.error(__(`Invalid claim ID %claimId%.`, { claimId }));
+    throw new Error(__(`Invalid claim ID %claimId%.`, { claimId }));
   }
 
   if (claimSequence && !claimSequence.match(/^-?[1-9][0-9]*$/)) {
-    console.error(__('Claim sequence must be a number.'));
+    throw new Error(__('Claim sequence must be a number.'));
   }
 
   if (bidPosition && !bidPosition.match(/^-?[1-9][0-9]*$/)) {
-    console.error(__('Bid position must be a number.'));
+    throw new Error(__('Bid position must be a number.'));
   }
 
   return [claimId, claimSequence, bidPosition];

--- a/src/redux/actions/search.js
+++ b/src/redux/actions/search.js
@@ -75,10 +75,13 @@ export const doUpdateSearchQuery = (query: string, shouldSkipSuggestions: ?boole
 };
 
 export const doSearch = (
-  rawQuery: string, // pass in a query if you don't want to search for what's in the search bar
+  rawQuery: string,
   size: ?number, // only pass in if you don't want to use the users setting (ex: related content)
   from: ?number,
-  isBackgroundSearch: boolean = false
+  isBackgroundSearch: boolean = false,
+  options: {
+    related_to?: string,
+  } = {}
 ) => (dispatch: Dispatch, getState: GetState) => {
   const query = rawQuery.replace(/^lbry:\/\//i, '').replace(/\//, ' ');
 
@@ -90,7 +93,9 @@ export const doSearch = (
   }
 
   const state = getState();
-  const queryWithOptions = makeSelectQueryWithOptions(query, size, from, isBackgroundSearch)(state);
+  let queryWithOptions = makeSelectQueryWithOptions(query, size, from, isBackgroundSearch, options)(
+    state
+  );
 
   // If we have already searched for something, we don't need to do anything
   const urisForQuery = makeSelectSearchUris(queryWithOptions)(state);
@@ -150,6 +155,8 @@ export const doSearch = (
       });
     });
 };
+
+export const doSearchForRelatedContent = (query: string) => {};
 
 export const doFocusSearchInput = () => (dispatch: Dispatch) =>
   dispatch({

--- a/src/redux/actions/search.js
+++ b/src/redux/actions/search.js
@@ -156,8 +156,6 @@ export const doSearch = (
     });
 };
 
-export const doSearchForRelatedContent = (query: string) => {};
-
 export const doFocusSearchInput = () => (dispatch: Dispatch) =>
   dispatch({
     type: ACTIONS.SEARCH_FOCUS,

--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -13,27 +13,31 @@ export function doUpdateBalance() {
     } = getState();
 
     if (walletBalancePromise === null) {
-      walletBalancePromise = Lbry.wallet_balance().then(response => {
-        walletBalancePromise = null;
+      walletBalancePromise = Lbry.wallet_balance()
+        .then(response => {
+          walletBalancePromise = null;
 
-        const { available, reserved, reserved_subtotals, total } = response;
-        const { claims, supports, tips } = reserved_subtotals;
-        const totalFloat = parseFloat(total);
+          const { available, reserved, reserved_subtotals, total } = response;
+          const { claims, supports, tips } = reserved_subtotals;
+          const totalFloat = parseFloat(total);
 
-        if (totalInStore !== totalFloat) {
-          dispatch({
-            type: ACTIONS.UPDATE_BALANCE,
-            data: {
-              totalBalance: totalFloat,
-              balance: parseFloat(available),
-              reservedBalance: parseFloat(reserved),
-              claimsBalance: parseFloat(claims),
-              supportsBalance: parseFloat(supports),
-              tipsBalance: parseFloat(tips),
-            },
-          });
-        }
-      });
+          if (totalInStore !== totalFloat) {
+            dispatch({
+              type: ACTIONS.UPDATE_BALANCE,
+              data: {
+                totalBalance: totalFloat,
+                balance: parseFloat(available),
+                reservedBalance: parseFloat(reserved),
+                claimsBalance: parseFloat(claims),
+                supportsBalance: parseFloat(supports),
+                tipsBalance: parseFloat(tips),
+              },
+            });
+          }
+        })
+        .catch(() => {
+          walletBalancePromise = null;
+        });
     }
 
     return walletBalancePromise;

--- a/src/redux/selectors/claims.js
+++ b/src/redux/selectors/claims.js
@@ -212,7 +212,6 @@ export const makeSelectTotalPagesInChannelSearch = (uri: string) =>
     }
   );
 
-
 export const makeSelectClaimsInChannelForCurrentPageState = (uri: string) =>
   createSelector(
     selectClaimsById,
@@ -261,8 +260,8 @@ export const makeSelectDateForUri = (uri: string) =>
         (claim.value.release_time
           ? claim.value.release_time * 1000
           : claim.meta && claim.meta.creation_timestamp
-          ? claim.meta.creation_timestamp * 1000
-          : null);
+            ? claim.meta.creation_timestamp * 1000
+            : null);
       if (!timestamp) {
         return undefined;
       }
@@ -473,8 +472,7 @@ export const makeSelectOmittedCountForChannel = (uri: string) =>
     (claimsInChannel, claimsInSearch) => {
       if (claimsInChannel && typeof claimsInSearch === 'number' && claimsInSearch >= 0) {
         return claimsInChannel - claimsInSearch;
-      }
-      else return 0;
+      } else return 0;
     }
   );
 
@@ -508,7 +506,13 @@ export const makeSelectRecommendedContentForUri = (uri: string) =>
 
         const { title } = claim.value;
 
-        const searchQuery = getSearchQueryString(title ? title.replace(/\//, ' ') : '');
+        if (!title) {
+          return;
+        }
+
+        const searchQuery = getSearchQueryString(title, undefined, undefined, {
+          related_to: claim.claim_id,
+        });
 
         let searchUris = searchUrisByQuery[searchQuery];
         if (searchUris) {
@@ -625,11 +629,9 @@ export const makeSelectMyStreamUrlsForPage = (page: number = 1) =>
   createSelector(
     selectMyClaimUrisWithoutChannels,
     urls => {
-      const start = ((Number(page) - 1) * Number(PAGE_SIZE));
-      const end = (Number(page) * Number(PAGE_SIZE));
-      return (urls && urls.length)
-        ? urls.slice(start, end)
-        : [];
+      const start = (Number(page) - 1) * Number(PAGE_SIZE);
+      const end = Number(page) * Number(PAGE_SIZE);
+      return urls && urls.length ? urls.slice(start, end) : [];
     }
   );
 

--- a/src/redux/selectors/claims.js
+++ b/src/redux/selectors/claims.js
@@ -260,8 +260,8 @@ export const makeSelectDateForUri = (uri: string) =>
         (claim.value.release_time
           ? claim.value.release_time * 1000
           : claim.meta && claim.meta.creation_timestamp
-            ? claim.meta.creation_timestamp * 1000
-            : null);
+          ? claim.meta.creation_timestamp * 1000
+          : null);
       if (!timestamp) {
         return undefined;
       }
@@ -510,7 +510,7 @@ export const makeSelectRecommendedContentForUri = (uri: string) =>
           return;
         }
 
-        const searchQuery = getSearchQueryString(title, undefined, undefined, {
+        const searchQuery = getSearchQueryString(title.replace(/\//, ' '), undefined, undefined, {
           related_to: claim.claim_id,
         });
 

--- a/src/redux/selectors/search.js
+++ b/src/redux/selectors/search.js
@@ -137,7 +137,10 @@ export const makeSelectQueryWithOptions = (
   customQuery: ?string,
   customSize: ?number,
   customFrom: ?number,
-  isBackgroundSearch: boolean = false // If it's a background search, don't use the users settings
+  isBackgroundSearch: boolean = false, // If it's a background search, don't use the users settings
+  additionalOptions: {
+    related_to?: string,
+  } = {}
 ) =>
   createSelector(
     selectSearchValue,
@@ -148,7 +151,8 @@ export const makeSelectQueryWithOptions = (
       const queryString = getSearchQueryString(
         customQuery || query,
         { ...options, size, from: customFrom },
-        !isBackgroundSearch
+        !isBackgroundSearch,
+        additionalOptions
       );
 
       return queryString;

--- a/src/util/query-params.js
+++ b/src/util/query-params.js
@@ -36,7 +36,8 @@ export function toQueryString(params: { [string]: string | number }) {
 export const getSearchQueryString = (
   query: string,
   options: any = {},
-  includeUserOptions: boolean = false
+  includeUserOptions: boolean = false,
+  additionalOptions: {} = {}
 ) => {
   const encodedQuery = encodeURIComponent(query);
   const queryParams = [
@@ -65,6 +66,13 @@ export const getSearchQueryString = (
         )}`
       );
     }
+  }
+
+  if (additionalOptions) {
+    Object.keys(additionalOptions).forEach(key => {
+      const option = additionalOptions[key];
+      queryParams.push(`${key}=${option}`);
+    });
   }
 
   return queryParams.join('&');


### PR DESCRIPTION
https://lbryians.slack.com/archives/C1R07H02X/p1576641588024400?thread_ts=1576637646.019900&cid=C1R07H02X

I think we should just get rid of the search caching, it makes everything so complex. I'd like to do some cleanup when I start working on it more app side, but this should do for now. Passing `related_to={claim_id}` is needed to improve related content a lot.