### PR TITLE
add optional resolveResults parameter to doSearch

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -3910,7 +3910,7 @@ const doUpdateSearchQuery = (query, shouldSkipSuggestions) => dispatch => {
 
 const doSearch = (rawQuery, // pass in a query if you don't want to search for what's in the search bar
 size, // only pass in if you don't want to use the users setting (ex: related content)
-from, isBackgroundSearch = false) => (dispatch, getState) => {
+from, isBackgroundSearch = false, resolveResults = true) => (dispatch, getState) => {
   const query = rawQuery.replace(/^lbry:\/\//i, '').replace(/\//, ' ');
 
   if (!query) {
@@ -3959,7 +3959,9 @@ from, isBackgroundSearch = false) => (dispatch, getState) => {
         }
 
         const url = buildURI(urlObj);
-        actions.push(doResolveUri(url));
+        if (resolveResults) {
+          actions.push(doResolveUri(url));
+        }
         uris.push(url);
       }
     });

--- a/src/redux/actions/search.js
+++ b/src/redux/actions/search.js
@@ -78,7 +78,8 @@ export const doSearch = (
   rawQuery: string, // pass in a query if you don't want to search for what's in the search bar
   size: ?number, // only pass in if you don't want to use the users setting (ex: related content)
   from: ?number,
-  isBackgroundSearch: boolean = false
+  isBackgroundSearch: boolean = false,
+  resolveResults: boolean = true,
 ) => (dispatch: Dispatch, getState: GetState) => {
   const query = rawQuery.replace(/^lbry:\/\//i, '').replace(/\//, ' ');
 
@@ -130,7 +131,9 @@ export const doSearch = (
           }
 
           const url = buildURI(urlObj);
-          actions.push(doResolveUri(url));
+          if (resolveResults) {
+            actions.push(doResolveUri(url));
+          }
           uris.push(url);
         }
       });


### PR DESCRIPTION
This lets me be able to batch resolve the returned URLs instead of waiting for each resolve to return one at a time due to performance reasons.