### PR TITLE
Fix timestamp if channel has the same name as URL

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -3748,6 +3748,8 @@ const doPublish = (success, fail) => (dispatch, getState) => {
     tags,
     locations
   } = publishData;
+  // Handle scenario where we have a claim that has the same name as a channel we are publishing with.
+  const myClaimForUriEditing = myClaimForUri.name === name ? myClaimForUri : null;
 
   let publishingLicense;
   switch (licenseType) {
@@ -3791,10 +3793,10 @@ const doPublish = (success, fail) => (dispatch, getState) => {
   }
 
   // Set release time to curret date. On edits, keep original release/transaction time as release_time
-  if (myClaimForUri && myClaimForUri.value.release_time) {
+  if (myClaimForUriEditing && myClaimForUriEditing.value.release_time) {
     publishPayload.release_time = Number(myClaimForUri.value.release_time);
-  } else if (myClaimForUri && myClaimForUri.timestamp) {
-    publishPayload.release_time = Number(myClaimForUri.timestamp);
+  } else if (myClaimForUriEditing && myClaimForUriEditing.timestamp) {
+    publishPayload.release_time = Number(myClaimForUriEditing.timestamp);
   } else {
     publishPayload.release_time = Number(Math.round(Date.now() / 1000));
   }
@@ -3803,8 +3805,8 @@ const doPublish = (success, fail) => (dispatch, getState) => {
     publishPayload.channel_id = channelId;
   }
 
-  if (myClaimForUri && myClaimForUri.value && myClaimForUri.value.locations) {
-    publishPayload.locations = myClaimForUri.value.locations;
+  if (myClaimForUriEditing && myClaimForUriEditing.value && myClaimForUriEditing.value.locations) {
+    publishPayload.locations = myClaimForUriEditing.value.locations;
   }
 
   if (!contentIsFree && fee && fee.currency && Number(fee.amount) > 0) {

--- a/src/redux/actions/publish.js
+++ b/src/redux/actions/publish.js
@@ -265,6 +265,8 @@ export const doPublish = (success: Function, fail: Function) => (
     tags,
     locations,
   } = publishData;
+  // Handle scenario where we have a claim that has the same name as a channel we are publishing with.
+  const myClaimForUriEditing = myClaimForUri.name === name ? myClaimForUri : null;
 
   let publishingLicense;
   switch (licenseType) {
@@ -327,10 +329,10 @@ export const doPublish = (success: Function, fail: Function) => (
   }
 
   // Set release time to curret date. On edits, keep original release/transaction time as release_time
-  if (myClaimForUri && myClaimForUri.value.release_time) {
+  if (myClaimForUriEditing && myClaimForUriEditing.value.release_time) {
     publishPayload.release_time = Number(myClaimForUri.value.release_time);
-  } else if (myClaimForUri && myClaimForUri.timestamp) {
-    publishPayload.release_time = Number(myClaimForUri.timestamp);
+  } else if (myClaimForUriEditing && myClaimForUriEditing.timestamp) {
+    publishPayload.release_time = Number(myClaimForUriEditing.timestamp);
   } else {
     publishPayload.release_time = Number(Math.round(Date.now() / 1000));
   }
@@ -339,8 +341,8 @@ export const doPublish = (success: Function, fail: Function) => (
     publishPayload.channel_id = channelId;
   }
 
-  if (myClaimForUri && myClaimForUri.value && myClaimForUri.value.locations) {
-    publishPayload.locations = myClaimForUri.value.locations;
+  if (myClaimForUriEditing && myClaimForUriEditing.value && myClaimForUriEditing.value.locations) {
+    publishPayload.locations = myClaimForUriEditing.value.locations;
   }
 
   if (!contentIsFree && fee && (fee.currency && Number(fee.amount) > 0)) {


### PR DESCRIPTION
There is a deeper issue on edits - will still show you are editing, but at least this would let you publish with the right timestamp. 