### PR TITLE
Enforce channel comments

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -1618,7 +1618,14 @@ var _extends$2 = Object.assign || function (target) { for (var i = 1; i < argume
 
 function extractUserState(rawObj) {
   if (rawObj && rawObj.version === '0.1' && rawObj.value) {
-    const { subscriptions, tags, blocked, settings, app_welcome_version, sharing_3P } = rawObj.value;
+    const {
+      subscriptions,
+      tags,
+      blocked,
+      settings,
+      app_welcome_version,
+      sharing_3P
+    } = rawObj.value;
 
     return _extends$2({}, subscriptions ? { subscriptions } : {}, tags ? { tags } : {}, blocked ? { blocked } : {}, settings ? { settings } : {}, app_welcome_version ? { app_welcome_version } : {}, sharing_3P ? { sharing_3P } : {});
   }
@@ -1628,10 +1635,24 @@ function extractUserState(rawObj) {
 
 function doPopulateSharedUserState(sharedSettings) {
   return dispatch => {
-    const { subscriptions, tags, blocked, settings, app_welcome_version, sharing_3P } = extractUserState(sharedSettings);
+    const {
+      subscriptions,
+      tags,
+      blocked,
+      settings,
+      app_welcome_version,
+      sharing_3P
+    } = extractUserState(sharedSettings);
     dispatch({
       type: USER_STATE_POPULATE,
-      data: { subscriptions, tags, blocked, settings, welcomeVersion: app_welcome_version, allowAnalytics: sharing_3P }
+      data: {
+        subscriptions,
+        tags,
+        blocked,
+        settings,
+        welcomeVersion: app_welcome_version,
+        allowAnalytics: sharing_3P
+      }
     });
   };
 }
@@ -4365,9 +4386,23 @@ function doCommentCreate(comment = '', claim_id = '', channel, parent_id) {
     dispatch({
       type: COMMENT_CREATE_STARTED
     });
+
     const myChannels = selectMyChannelClaims(state);
     const namedChannelClaim = myChannels && myChannels.find(myChannel => myChannel.name === channel);
-    const channel_id = namedChannelClaim ? namedChannelClaim.claim_id : null;
+    const channel_id = namedChannelClaim.claim_id;
+
+    if (channel_id == null) {
+      dispatch({
+        type: COMMENT_CREATE_FAILED,
+        data: {}
+      });
+      dispatch(doToast({
+        message: 'Channel cannot be anonymous, please select a channel and try again.',
+        isError: true
+      }));
+      return;
+    }
+
     return lbryProxy.comment_create({
       comment: comment,
       claim_id: claim_id,

--- a/src/redux/actions/comments.js
+++ b/src/redux/actions/comments.js
@@ -50,10 +50,26 @@ export function doCommentCreate(
     dispatch({
       type: ACTIONS.COMMENT_CREATE_STARTED,
     });
+
     const myChannels = selectMyChannelClaims(state);
     const namedChannelClaim =
       myChannels && myChannels.find(myChannel => myChannel.name === channel);
-    const channel_id = namedChannelClaim ? namedChannelClaim.claim_id : null;
+    const channel_id = namedChannelClaim.claim_id;
+
+    if (channel_id == null) {
+      dispatch({
+        type: ACTIONS.COMMENT_CREATE_FAILED,
+        data: {},
+      });
+      dispatch(
+        doToast({
+          message: 'Channel cannot be anonymous, please select a channel and try again.',
+          isError: true,
+        })
+      );
+      return;
+    }
+
     return Lbry.comment_create({
       comment: comment,
       claim_id: claim_id,

--- a/src/redux/actions/comments.js
+++ b/src/redux/actions/comments.js
@@ -42,7 +42,7 @@ export function doCommentList(uri: string, page: number = 1, pageSize: number = 
 export function doCommentCreate(
   comment: string = '',
   claim_id: string = '',
-  channel: ?string,
+  channel: string,
   parent_id?: string
 ) {
   return (dispatch: Dispatch, getState: GetState) => {

--- a/src/redux/actions/publish.js
+++ b/src/redux/actions/publish.js
@@ -119,12 +119,12 @@ export const doUploadThumbnail = (
         .then(json =>
           json.success
             ? dispatch({
-              type: ACTIONS.UPDATE_PUBLISH_FORM,
-              data: {
-                uploadThumbnailStatus: THUMBNAIL_STATUSES.COMPLETE,
-                thumbnail: `${json.data.url}.${fileExt}`,
-              },
-            })
+                type: ACTIONS.UPDATE_PUBLISH_FORM,
+                data: {
+                  uploadThumbnailStatus: THUMBNAIL_STATUSES.COMPLETE,
+                  thumbnail: `${json.data.url}.${fileExt}`,
+                },
+              })
             : uploadError(json.message)
         )
         .catch(err => uploadError(err.message));
@@ -159,12 +159,12 @@ export const doUploadThumbnail = (
       .then(json =>
         json.success
           ? dispatch({
-            type: ACTIONS.UPDATE_PUBLISH_FORM,
-            data: {
-              uploadThumbnailStatus: THUMBNAIL_STATUSES.COMPLETE,
-              thumbnail: `${json.data.url}${fileExt}`,
-            },
-          })
+              type: ACTIONS.UPDATE_PUBLISH_FORM,
+              data: {
+                uploadThumbnailStatus: THUMBNAIL_STATUSES.COMPLETE,
+                thumbnail: `${json.data.url}${fileExt}`,
+              },
+            })
           : uploadError(json.message)
       )
       .catch(err => uploadError(err.message));

--- a/src/redux/actions/sync.js
+++ b/src/redux/actions/sync.js
@@ -16,7 +16,14 @@ type SharedData = {
 
 function extractUserState(rawObj: SharedData) {
   if (rawObj && rawObj.version === '0.1' && rawObj.value) {
-    const { subscriptions, tags, blocked, settings, app_welcome_version, sharing_3P } = rawObj.value;
+    const {
+      subscriptions,
+      tags,
+      blocked,
+      settings,
+      app_welcome_version,
+      sharing_3P,
+    } = rawObj.value;
 
     return {
       ...(subscriptions ? { subscriptions } : {}),
@@ -24,7 +31,7 @@ function extractUserState(rawObj: SharedData) {
       ...(blocked ? { blocked } : {}),
       ...(settings ? { settings } : {}),
       ...(app_welcome_version ? { app_welcome_version } : {}),
-      ...(sharing_3P ? { sharing_3P} : {}),
+      ...(sharing_3P ? { sharing_3P } : {}),
     };
   }
 
@@ -33,10 +40,24 @@ function extractUserState(rawObj: SharedData) {
 
 export function doPopulateSharedUserState(sharedSettings: any) {
   return (dispatch: Dispatch) => {
-    const { subscriptions, tags, blocked, settings, app_welcome_version, sharing_3P } = extractUserState(sharedSettings);
+    const {
+      subscriptions,
+      tags,
+      blocked,
+      settings,
+      app_welcome_version,
+      sharing_3P,
+    } = extractUserState(sharedSettings);
     dispatch({
       type: ACTIONS.USER_STATE_POPULATE,
-      data: { subscriptions, tags, blocked, settings, welcomeVersion: app_welcome_version, allowAnalytics: sharing_3P },
+      data: {
+        subscriptions,
+        tags,
+        blocked,
+        settings,
+        welcomeVersion: app_welcome_version,
+        allowAnalytics: sharing_3P,
+      },
     });
   };
 }

--- a/src/redux/selectors/file_info.js
+++ b/src/redux/selectors/file_info.js
@@ -233,12 +233,12 @@ export const makeSelectSearchDownloadUrlsForPage = (query, page = 1) =>
 
       return matchingFileInfos && matchingFileInfos.length
         ? matchingFileInfos.slice(start, end).map(fileInfo =>
-          buildURI({
-            streamName: fileInfo.claim_name,
-            channelName: fileInfo.channel_name,
-            channelClaimId: fileInfo.channel_claim_id,
-          })
-        )
+            buildURI({
+              streamName: fileInfo.claim_name,
+              channelName: fileInfo.channel_name,
+              channelClaimId: fileInfo.channel_claim_id,
+            })
+          )
         : [];
     }
   );

--- a/src/redux/selectors/publish.js
+++ b/src/redux/selectors/publish.js
@@ -77,10 +77,10 @@ export const selectMyClaimForUri = createSelector(
     return isStillEditing
       ? claimsById[editClaimId]
       : myClaims.find(claim =>
-        !contentName
-          ? claim.name === claimName
-          : claim.name === contentName || claim.name === claimName
-      );
+          !contentName
+            ? claim.name === claimName
+            : claim.name === contentName || claim.name === claimName
+        );
   }
 );
 

--- a/src/redux/selectors/search.js
+++ b/src/redux/selectors/search.js
@@ -172,21 +172,15 @@ type CustomOptions = {
   from?: number,
   related_to?: string,
   nsfw?: boolean,
-}
+};
 
-export const makeSelectQueryWithOptions = (
-  customQuery: ?string,
-  options: CustomOptions,
-) =>
+export const makeSelectQueryWithOptions = (customQuery: ?string, options: CustomOptions) =>
   createSelector(
     selectSearchValue,
     selectSearchOptions,
     (query, defaultOptions) => {
       const searchOptions = { ...defaultOptions, ...options };
-      const queryString = getSearchQueryString(
-        customQuery || query,
-        searchOptions,
-      );
+      const queryString = getSearchQueryString(customQuery || query, searchOptions);
 
       return queryString;
     }

--- a/src/util/query-params.js
+++ b/src/util/query-params.js
@@ -33,10 +33,7 @@ export function toQueryString(params: { [string]: string | number }) {
   return parts.join('&');
 }
 
-export const getSearchQueryString = (
-  query: string,
-  options: any = {},
-) => {
+export const getSearchQueryString = (query: string, options: any = {}) => {
   const encodedQuery = encodeURIComponent(query);
   const queryParams = [
     `s=${encodedQuery}`,
@@ -44,7 +41,8 @@ export const getSearchQueryString = (
     `from=${options.from || DEFAULT_SEARCH_RESULT_FROM}`,
   ];
   const { isBackgroundSearch } = options;
-  const includeUserOptions = typeof isBackgroundSearch === 'undefined' ? false : !isBackgroundSearch;
+  const includeUserOptions =
+    typeof isBackgroundSearch === 'undefined' ? false : !isBackgroundSearch;
 
   if (includeUserOptions) {
     const claimType = options[SEARCH_OPTIONS.CLAIM_TYPE];
@@ -70,7 +68,7 @@ export const getSearchQueryString = (
     }
   }
 
-  const additionalOptions = {}
+  const additionalOptions = {};
   const { related_to } = options;
   const { nsfw } = options;
   if (related_to) additionalOptions['related_to'] = related_to;


### PR DESCRIPTION
Sets the `Channel` param as mandatory in `commentCreate`, and provides a toast for the situation. 