### PR TITLE
use canonical_url when returning own claim urls and fix lint

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2206,7 +2206,7 @@ const selectMyClaimUrisWithoutChannels = reselect.createSelector(selectMyClaimsW
   } else {
     return b.timestamp - a.timestamp;
   }
-}).map(claim => `lbry://${claim.name}#${claim.claim_id}`));
+}).map(claim => claim.canonical_url));
 
 const selectAllMyClaimsByOutpoint = reselect.createSelector(selectMyClaimsRaw, claims => new Set(claims && claims.length ? claims.map(claim => `${claim.txid}:${claim.nout}`) : null));
 
@@ -2920,6 +2920,7 @@ function doFetchClaimListMine(page = 1, pageSize = 99999, resolve = true) {
       type: FETCH_CLAIM_LIST_MINE_STARTED
     });
 
+    // $FlowFixMe
     lbryProxy.claim_list({ page, page_size: pageSize, claim_type: ['stream', 'repost'], resolve }).then(result => {
       const claims = result.items;
 
@@ -4210,14 +4211,11 @@ from, isBackgroundSearch = false, options = {}, nsfw) => (dispatch, getState) =>
     return;
   }
 
-  const optionsWithFrom = _extends$8({
-    size,
-    from,
+  const optionsWithFrom = _extends$8({}, size ? { size } : {}, from ? { from } : {}, {
     isBackgroundSearch
   }, options);
 
-  const optionsWithoutFrom = _extends$8({
-    size,
+  const optionsWithoutFrom = _extends$8({}, size ? { size } : {}, {
     isBackgroundSearch
   }, options);
 

--- a/src/redux/actions/claims.js
+++ b/src/redux/actions/claims.js
@@ -104,6 +104,7 @@ export function doFetchClaimListMine(
       type: ACTIONS.FETCH_CLAIM_LIST_MINE_STARTED,
     });
 
+    // $FlowFixMe
     Lbry.claim_list({ page, page_size: pageSize, claim_type: ['stream', 'repost'], resolve }).then(
       (result: StreamListResponse) => {
         const claims = result.items;

--- a/src/redux/actions/search.js
+++ b/src/redux/actions/search.js
@@ -184,14 +184,14 @@ export const doResolvedSearch = (
   }
 
   const optionsWithFrom: SearchOptions = {
-    size,
-    from,
+    ...(size ? { size } : {}),
+    ...(from ? { from } : {}),
     isBackgroundSearch,
     ...options,
   };
 
   const optionsWithoutFrom: SearchOptions = {
-    size,
+    ...(size ? { size } : {}),
     isBackgroundSearch,
     ...options,
   };

--- a/src/redux/selectors/claims.js
+++ b/src/redux/selectors/claims.js
@@ -290,8 +290,8 @@ export const makeSelectDateForUri = (uri: string) =>
         (claim.value.release_time
           ? claim.value.release_time * 1000
           : claim.meta && claim.meta.creation_timestamp
-          ? claim.meta.creation_timestamp * 1000
-          : null);
+            ? claim.meta.creation_timestamp * 1000
+            : null);
       if (!timestamp) {
         return undefined;
       }
@@ -377,7 +377,7 @@ export const selectMyClaimUrisWithoutChannels = createSelector(
           return b.timestamp - a.timestamp;
         }
       })
-      .map(claim => `lbry://${claim.name}#${claim.claim_id}`)
+      .map(claim => claim.canonical_url)
 );
 
 export const selectAllMyClaimsByOutpoint = createSelector(


### PR DESCRIPTION
Now that claim_list includes resolve information, we can use canonical_url. This is needed so we can show the repost channel when listing users publishes.