### PR TITLE
save optimize check state to allow page navigation

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -5492,6 +5492,10 @@ function _objectWithoutProperties$3(obj, keys) { var target = {}; for (var i in 
 const defaultState$6 = {
   editingURI: undefined,
   filePath: undefined,
+  checkFileDur: 0,
+  checkFileSize: 0,
+  checkFileVid: false,
+  canOptimize: undefined,
   contentIsFree: true,
   fee: {
     amount: 1,

--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -5492,10 +5492,9 @@ function _objectWithoutProperties$3(obj, keys) { var target = {}; for (var i in 
 const defaultState$6 = {
   editingURI: undefined,
   filePath: undefined,
-  checkFileDur: 0,
-  checkFileSize: 0,
-  checkFileVid: false,
-  canOptimize: undefined,
+  fileDur: 0,
+  fileSize: 0,
+  fileVid: false,
   contentIsFree: true,
   fee: {
     amount: 1,
@@ -5529,7 +5528,9 @@ const publishReducer = handleActions({
     const { data } = action;
     return _extends$e({}, state, data);
   },
-  [CLEAR_PUBLISH]: state => _extends$e({}, defaultState$6, { bid: state.bid, optimize: state.optimize
+  [CLEAR_PUBLISH]: state => _extends$e({}, defaultState$6, {
+    bid: state.bid,
+    optimize: state.optimize
   }),
   [PUBLISH_START]: state => _extends$e({}, state, {
     publishing: true,

--- a/src/redux/reducers/publish.js
+++ b/src/redux/reducers/publish.js
@@ -9,6 +9,10 @@ type PublishState = {
   editingURI: ?string,
   filePath: ?string,
   contentIsFree: boolean,
+  canOptimize: ?boolean,
+  checkFileDur: number,
+  checkFileSize: number,
+  checkFileVid: boolean,
   fee: {
     amount: number,
     currency: string,
@@ -34,6 +38,10 @@ type PublishState = {
 const defaultState: PublishState = {
   editingURI: undefined,
   filePath: undefined,
+  checkFileDur: 0,
+  checkFileSize: 0,
+  checkFileVid: false,
+  canOptimize: undefined,
   contentIsFree: true,
   fee: {
     amount: 1,
@@ -72,7 +80,9 @@ export const publishReducer = handleActions(
       };
     },
     [ACTIONS.CLEAR_PUBLISH]: (state: PublishState): PublishState => ({
-      ...defaultState, bid: state.bid, optimize: state.optimize,
+      ...defaultState,
+      bid: state.bid,
+      optimize: state.optimize,
     }),
     [ACTIONS.PUBLISH_START]: (state: PublishState): PublishState => ({
       ...state,

--- a/src/redux/reducers/publish.js
+++ b/src/redux/reducers/publish.js
@@ -9,10 +9,9 @@ type PublishState = {
   editingURI: ?string,
   filePath: ?string,
   contentIsFree: boolean,
-  canOptimize: ?boolean,
-  checkFileDur: number,
-  checkFileSize: number,
-  checkFileVid: boolean,
+  fileDur: number,
+  fileSize: number,
+  fileVid: boolean,
   fee: {
     amount: number,
     currency: string,
@@ -38,10 +37,9 @@ type PublishState = {
 const defaultState: PublishState = {
   editingURI: undefined,
   filePath: undefined,
-  checkFileDur: 0,
-  checkFileSize: 0,
-  checkFileVid: false,
-  canOptimize: undefined,
+  fileDur: 0,
+  fileSize: 0,
+  fileVid: false,
   contentIsFree: true,
   fee: {
     amount: 1,


### PR DESCRIPTION
This addresses navigating away from publish page after having selected a file. Browser security doesn't make it simple to load a file the same as an <input> does without a user-triggered action.