### PR TITLE
Enable webp images

### DIFF
--- a/src/lbry.js
+++ b/src/lbry.js
@@ -40,7 +40,7 @@ const Lbry: LbryTypes = {
       const formats = [
         [/\.(mp4|m4v|webm|flv|f4v|ogv)$/i, 'video'],
         [/\.(mp3|m4a|aac|wav|flac|ogg|opus)$/i, 'audio'],
-        [/\.(jpeg|jpg|png|gif|svg)$/i, 'image'],
+        [/\.(jpeg|jpg|png|gif|svg|webp)$/i, 'image'],
         [/\.(h|go|ja|java|js|jsx|c|cpp|cs|css|rb|scss|sh|php|py)$/i, 'script'],
         [/\.(html|json|csv|txt|log|md|markdown|docx|pdf|xml|yml|yaml)$/i, 'document'],
         [/\.(pdf|odf|doc|docx|epub|org|rtf)$/i, 'e-book'],


### PR DESCRIPTION
Fixes for: Webp support https://github.com/lbryio/lbry-desktop/issues/4146

> WebP is natively supported in Google Chrome, Firefox, Edge, the Opera browser, and by many other tools and software libraries. Developers have also added support to a variety of image editing tools.
See: https://developers.google.com/speed/webp#webp_support

> Note The comic-book viewer already support this image type.