### PR TITLE
Support lbry:// links with timestamp

### DIFF
--- a/flow-typed/lbryURI.js
+++ b/flow-typed/lbryURI.js
@@ -12,6 +12,7 @@ declare type LbryUrlObj = {
   secondaryClaimSequence?: number,
   primaryBidPosition?: number,
   secondaryBidPosition?: number,
+  startTime?: number,
 
   // Below are considered deprecated and should not be used due to unreliableness with claim.canonical_url
   claimName?: string,

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -60,6 +60,8 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
     secondaryModSeparator,
     secondaryModValue,
   ] = rest;
+  const searchParams = new URLSearchParams(qs || '');
+  const startTime = searchParams.get('t');
 
   // Validate protocol
   if (requireProto && !proto) {
@@ -121,6 +123,7 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
       : {}),
     ...(primaryBidPosition ? { primaryBidPosition: parseInt(primaryBidPosition, 10) } : {}),
     ...(secondaryBidPosition ? { secondaryBidPosition: parseInt(secondaryBidPosition, 10) } : {}),
+    ...(startTime ? { startTime: parseInt(startTime, 10) } : {}),
 
     // The values below should not be used for new uses of parseURI
     // They will not work properly with canonical_urls
@@ -184,6 +187,7 @@ export function buildURI(
     primaryBidPosition,
     secondaryClaimSequence,
     secondaryBidPosition,
+    startTime,
     ...deprecatedParts
   } = UrlObj;
   const { claimId, claimName, contentName } = deprecatedParts;
@@ -233,7 +237,8 @@ export function buildURI(
     (secondaryClaimName ? `/${secondaryClaimName}` : '') +
     (secondaryClaimId ? `#${secondaryClaimId}` : '') +
     (secondaryClaimSequence ? `:${secondaryClaimSequence}` : '') +
-    (secondaryBidPosition ? `${secondaryBidPosition}` : '')
+    (secondaryBidPosition ? `${secondaryBidPosition}` : '') +
+    (startTime ? `?t=${startTime}` : '')
   );
 }
 
@@ -248,6 +253,7 @@ export function normalizeURI(URL: string) {
     primaryBidPosition,
     secondaryClaimSequence,
     secondaryBidPosition,
+    startTime,
   } = parseURI(URL);
 
   return buildURI({
@@ -259,6 +265,7 @@ export function normalizeURI(URL: string) {
     primaryBidPosition,
     secondaryClaimSequence,
     secondaryBidPosition,
+    startTime,
   });
 }
 


### PR DESCRIPTION
Current behavior:
If you paste a lbry:// link with a ?t=xyz parameter at the end into the wunderbar, it will start the video at the beginning.

New behavior:
If you paste a lbry:// link with a ?t=xxx parameter at the end into the wunderbar, it will start the video at the xyz seconds timestamp.

This should fix https://github.com/lbryio/lbry-desktop/issues/3972