### PR TITLE
Add file text to publish state

### DIFF
--- a/src/redux/reducers/publish.js
+++ b/src/redux/reducers/publish.js
@@ -7,6 +7,7 @@ import { CHANNEL_ANONYMOUS } from 'constants/claim';
 
 type PublishState = {
   editingURI: ?string,
+  fileText: ?string,
   filePath: ?string,
   contentIsFree: boolean,
   fileDur: number,
@@ -36,6 +37,7 @@ type PublishState = {
 
 const defaultState: PublishState = {
   editingURI: undefined,
+  fileText: '',
   filePath: undefined,
   fileDur: 0,
   fileSize: 0,


### PR DESCRIPTION
> Edit previous text or markdown posts directly in the app

Added the contents of the file as string if contentType is "text", this value will be used for the markdown editor
Required by In-app text and markdown publishing and editing [#4105](https://github.com/lbryio/lbry-desktop/issues/4105)