### PR TITLE
Publish: Make 'channel' persistent by not clearing it in CLEAR_PUBLISH

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -5619,6 +5619,7 @@ const publishReducer = handleActions({
     return _extends$c({}, state, data);
   },
   [CLEAR_PUBLISH]: state => _extends$c({}, defaultState$4, {
+    channel: state.channel,
     bid: state.bid,
     optimize: state.optimize
   }),

--- a/src/redux/reducers/publish.js
+++ b/src/redux/reducers/publish.js
@@ -83,6 +83,7 @@ export const publishReducer = handleActions(
     },
     [ACTIONS.CLEAR_PUBLISH]: (state: PublishState): PublishState => ({
       ...defaultState,
+      channel: state.channel,
       bid: state.bid,
       optimize: state.optimize,
     }),


### PR DESCRIPTION
Users are annoyed by the constant reset to 'Anonymous'.