### PR TITLE
Add parseURI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ yarn link lbry-redux
 ### Build
 Run `$ yarn build`. If the symlink does not work, just build the file and move the `bundle.js` file into the `node_modules/` folder.
 
+### Tests
+Run `$ yarn test`.
+
 ## Contributing 
 We :heart: contributions from everyone! We welcome [bug reports](https://github.com/lbryio/lbry-redux/issues/), [bug fixes](https://github.com/lbryio/lbry-redux/pulls) and feedback on the module is always appreciated.
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  collectCoverageFrom: ["src/**/*.{js,jsx,mjs}"],
+  testMatch: ["<rootDir>/tests/**/*.test.js"],
+  transform: {
+    "^.+\\.(js|jsx|mjs)$": "<rootDir>/tests/config/jest-transformer.js",
+  },
+  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs)$"]
+};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "dev": "rollup --config --watch",
     "precommit": "flow check && lint-staged",
     "lint": "eslint 'src/**/*.js' --fix",
-    "format": "prettier 'src/**/*.{js,json}' --write"
+    "format": "prettier 'src/**/*.{js,json}' --write",
+    "test": "jest"
   },
   "dependencies": {
     "proxy-polyfill": "0.1.6",
@@ -33,6 +34,11 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.10.4",
+    "@babel/plugin-proposal-decorators": "^7.10.5",
+    "@babel/plugin-transform-flow-strip-types": "^7.10.4",
+    "@babel/preset-env": "^7.11.0",
+    "@babel/preset-react": "^7.10.4",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.3",
     "babel-loader": "^7.1.4",
@@ -53,6 +59,7 @@
     "flow-bin": "^0.97.0",
     "flow-typed": "^2.5.1",
     "husky": "^0.14.3",
+    "jest": "^26.4.2",
     "lint-staged": "^7.0.4",
     "prettier": "^1.4.2",
     "rollup": "^1.8.0",

--- a/tests/config/jest-transformer.js
+++ b/tests/config/jest-transformer.js
@@ -1,0 +1,19 @@
+const config = {
+  babelrc: false,
+  presets: [
+    [
+      "@babel/env",
+      {
+        modules: false
+      }
+    ],
+    "@babel/react"
+  ],
+  plugins: [
+    ["@babel/plugin-proposal-decorators", { legacy: true }],
+    ["@babel/plugin-proposal-class-properties", { loose: true }],
+    "@babel/plugin-transform-flow-strip-types",
+    "transform-es2015-modules-commonjs"
+  ]
+};
+module.exports = require("babel-jest").createTransformer(config);

--- a/tests/parseURI.test.js
+++ b/tests/parseURI.test.js
@@ -1,0 +1,44 @@
+import * as lbryURI from '../src/lbryURI.js';
+import {describe, test} from "@jest/globals";
+
+describe('parseURI tests', () => {
+
+    test('Correctly parses channel URI', () => {
+        let result = lbryURI.parseURI('lbry://@ChannelName');
+        expect(result.isChannel).toBeTruthy();
+        expect(result.path).toStrictEqual("@ChannelName");
+        expect(result.channelName).toStrictEqual("ChannelName");
+        expect(result.claimName).toStrictEqual("@ChannelName");
+    });
+
+    test('Correctly parses test case channel/stream lbry URI', () => {
+        let result = lbryURI.parseURI('lbry://@CryptoGnome#1/whale-pool-how-to#e');
+        expect(result.isChannel).toStrictEqual(false);;
+        expect(result.path).toStrictEqual("@CryptoGnome#1/whale-pool-how-to#e");
+        expect(result.claimId).toStrictEqual("1");
+        expect(result.streamClaimId).toStrictEqual("e");
+        expect(result.streamName).toStrictEqual("whale-pool-how-to");
+        expect(result.channelName).toStrictEqual("CryptoGnome");
+        expect(result.contentName).toStrictEqual("whale-pool-how-to");
+    });
+
+    test('Correctly parses lbry URI without protocol', () => {
+        let result = lbryURI.parseURI('@CryptoGnome#1/whale-pool-how-to#e');
+        expect(result.isChannel).toStrictEqual(false);;
+        expect(result.streamName).toStrictEqual("whale-pool-how-to");
+        expect(result.channelName).toStrictEqual("CryptoGnome");
+    });
+
+    test('Throws error for http protocol', () => {
+        // TODO - this catches wrong type of error..
+        let uri = 'http://@CryptoGnome#1/whale-pool-how-to#e';
+        expect(() => lbryURI.parseURI(uri)).toThrowError();
+    });
+
+    test('Correctly parses search', () => {
+        let result = lbryURI.parseURI('CryptoGn%ome');
+        expect(result.isChannel).toStrictEqual(false);
+        expect(result.path).toStrictEqual("CryptoGn%ome");
+        expect(result.contentName).toStrictEqual("CryptoGn%ome");
+    });
+})


### PR DESCRIPTION
Suspected there was a bug in parseURI (from strange behaviour seen in lbry-desktop).

Installed and configured jest testing, and added some tests in an attempt to replicate the suspected bug. Discovered that parseURI behaves as expected, but I think it would be good to add the tests anyway.

If this change is accepted, I will probably add more/better testing and include a CI pipeline for this repository.
