### PR TITLE
Fix untranslatable string.

### DIFF
--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -185,7 +185,7 @@ export function doSendDraftTransaction(address, amount) {
         });
         dispatch(
           doToast({
-            message: __(`You sent ${amount} LBRY Credits`),
+            message: __('You sent %amount% LBRY Credits', { amount: amount }),
             linkText: __('History'),
             linkTarget: '/wallet',
           })


### PR DESCRIPTION
Change to variable instead of resolving the variable in the string.