### PR TITLE
throw error instead of logging

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -1385,7 +1385,7 @@ const separateQuerystring = new RegExp(queryStringBreaker);
  *   - secondaryBidPosition (int, if present)
  */
 
-function parseURI(URL, requireProto = false) {
+function parseURI(url, requireProto = false) {
   // Break into components. Empty sub-matches are converted to null
 
   const componentsRegex = new RegExp(regexPartProtocol + // protocol
@@ -1395,12 +1395,12 @@ function parseURI(URL, requireProto = false) {
   regexPartStreamOrChannelName + regexPartModifierSeparator);
   // chop off the querystring first
   let QSStrippedURL, qs;
-  const qsRegexResult = separateQuerystring.exec(URL);
+  const qsRegexResult = separateQuerystring.exec(url);
   if (qsRegexResult) {
     [QSStrippedURL, qs] = qsRegexResult.slice(1).map(match => match || null);
   }
 
-  const cleanURL = QSStrippedURL || URL;
+  const cleanURL = QSStrippedURL || url;
   const regexMatch = componentsRegex.exec(cleanURL) || [];
   const [proto, ...rest] = regexMatch.slice(1).map(match => match || null);
   const path = rest.join('');
@@ -1420,7 +1420,7 @@ function parseURI(URL, requireProto = false) {
 
   rest.forEach(urlPiece => {
     if (urlPiece && urlPiece.includes(' ')) {
-      console.error('URL can not include a space');
+      throw new Error(__('URL can not include a space'));
     }
   });
 
@@ -4011,6 +4011,11 @@ function doPurchaseUri(uri, costInfo, saveFile = true, onSuccess) {
         type: PURCHASE_URI_FAILED,
         data: { uri, error: `Already fetching uri: ${uri}` }
       });
+
+      if (onSuccess) {
+        onSuccess(fileInfo);
+      }
+
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "proxy-polyfill": "0.1.6",
     "reselect": "^3.0.0",
-    "uuid": "^8.3.0"
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.10.4",

--- a/src/lbryURI.js
+++ b/src/lbryURI.js
@@ -29,7 +29,7 @@ const separateQuerystring = new RegExp(queryStringBreaker);
  *   - secondaryBidPosition (int, if present)
  */
 
-export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj {
+export function parseURI(url: string, requireProto: boolean = false): LbryUrlObj {
   // Break into components. Empty sub-matches are converted to null
 
   const componentsRegex = new RegExp(
@@ -42,12 +42,12 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
   );
   // chop off the querystring first
   let QSStrippedURL, qs;
-  const qsRegexResult = separateQuerystring.exec(URL);
+  const qsRegexResult = separateQuerystring.exec(url);
   if (qsRegexResult) {
     [QSStrippedURL, qs] = qsRegexResult.slice(1).map(match => match || null);
   }
 
-  const cleanURL = QSStrippedURL || URL;
+  const cleanURL = QSStrippedURL || url;
   const regexMatch = componentsRegex.exec(cleanURL) || [];
   const [proto, ...rest] = regexMatch.slice(1).map(match => match || null);
   const path = rest.join('');
@@ -75,7 +75,7 @@ export function parseURI(URL: string, requireProto: boolean = false): LbryUrlObj
 
   rest.forEach(urlPiece => {
     if (urlPiece && urlPiece.includes(' ')) {
-      console.error('URL can not include a space');
+      throw new Error(__('URL can not include a space'));
     }
   });
 

--- a/src/redux/actions/file.js
+++ b/src/redux/actions/file.js
@@ -104,7 +104,10 @@ export function doPurchaseUri(
         data: { uri, error: `Already fetching uri: ${uri}` },
       });
 
-      Promise.resolve();
+      if (onSuccess) {
+        onSuccess(fileInfo);
+      }
+
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8178,6 +8178,11 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
 v8-to-istanbul@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-5.0.1.tgz#0608f5b49a481458625edb058488607f25498ba5"


### PR DESCRIPTION
Now that android isn't using this, we can switch back to logging. All `parseURI` uses must be wrapped in a try/catch