### PR TITLE
claim_search: Don't clear previous page results if subsequent pages timeout.

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -5155,13 +5155,20 @@ reducers[CLAIM_SEARCH_FAILED] = (state, action) => {
   const { query } = action.data;
   const claimSearchByQuery = Object.assign({}, state.claimSearchByQuery);
   const fetchingClaimSearchByQuery = Object.assign({}, state.fetchingClaimSearchByQuery);
+  const claimSearchByQueryLastPageReached = Object.assign({}, state.claimSearchByQueryLastPageReached);
 
   delete fetchingClaimSearchByQuery[query];
-  claimSearchByQuery[query] = null;
+
+  if (claimSearchByQuery[query] && claimSearchByQuery[query].length !== 0) {
+    claimSearchByQueryLastPageReached[query] = true;
+  } else {
+    claimSearchByQuery[query] = null;
+  }
 
   return Object.assign({}, state, {
     fetchingClaimSearchByQuery,
-    claimSearchByQuery
+    claimSearchByQuery,
+    claimSearchByQueryLastPageReached
   });
 };
 

--- a/src/redux/reducers/claims.js
+++ b/src/redux/reducers/claims.js
@@ -570,13 +570,20 @@ reducers[ACTIONS.CLAIM_SEARCH_FAILED] = (state: State, action: any): State => {
   const { query } = action.data;
   const claimSearchByQuery = Object.assign({}, state.claimSearchByQuery);
   const fetchingClaimSearchByQuery = Object.assign({}, state.fetchingClaimSearchByQuery);
+  const claimSearchByQueryLastPageReached = Object.assign({}, state.claimSearchByQueryLastPageReached);
 
   delete fetchingClaimSearchByQuery[query];
-  claimSearchByQuery[query] = null;
+
+  if (claimSearchByQuery[query] && claimSearchByQuery[query].length !== 0) {
+    claimSearchByQueryLastPageReached[query] = true;
+  } else {
+    claimSearchByQuery[query] = null;
+  }
 
   return Object.assign({}, state, {
     fetchingClaimSearchByQuery,
     claimSearchByQuery,
+    claimSearchByQueryLastPageReached,
   });
 };
 


### PR DESCRIPTION
## Issue
https://github.com/lbryio/lbry-desktop/issues/4609

## Change
- Don't clear existing results on timeout.
- Mark the "no more results" flag so that the app knows it needs to stop querying.