### PR TITLE
Clear uri when clearing publish

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -5927,6 +5927,7 @@ const publishReducer = handleActions({
     return _extends$c({}, state, data);
   },
   [CLEAR_PUBLISH]: state => _extends$c({}, defaultState$4, {
+    uri: undefined,
     channel: state.channel,
     bid: state.bid,
     optimize: state.optimize,

--- a/src/redux/reducers/publish.js
+++ b/src/redux/reducers/publish.js
@@ -83,6 +83,7 @@ export const publishReducer = handleActions(
     },
     [ACTIONS.CLEAR_PUBLISH]: (state: PublishState): PublishState => ({
       ...defaultState,
+      uri: undefined,
       channel: state.channel,
       bid: state.bid,
       optimize: state.optimize,


### PR DESCRIPTION
Used by https://github.com/lbryio/lbry-desktop/pull/5578

It properly clears the `uri` property from the publish when clearing the form.

This prevents the following bug:

- Click on edit a claim
- Go back
- Clear form (by calling `doClearPublish`)
- Click on publish

![image](https://user-images.githubusercontent.com/1719111/109065484-6aab1380-76ca-11eb-9dde-fd7a10659b6c.png)

Since the `uri` field isn't cleared, the previous error is shown.