### PR TITLE
makeSelectClaimForUri: Use either canonical or permanent url for repost data

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2270,7 +2270,7 @@ const makeSelectClaimForUri = (uri, returnRepost = true) => reselect.createSelec
 
     const repostedClaim = claim && claim.reposted_claim;
     if (repostedClaim && returnRepost) {
-      const channelUrl = claim.signing_channel && claim.signing_channel.canonical_url;
+      const channelUrl = claim.signing_channel && (claim.signing_channel.canonical_url || claim.signing_channel.permanent_url);
 
       return _extends$3({}, repostedClaim, {
         repost_url: uri,

--- a/src/redux/selectors/claims.js
+++ b/src/redux/selectors/claims.js
@@ -127,7 +127,7 @@ export const makeSelectClaimForUri = (uri: string, returnRepost: boolean = true)
 
         const repostedClaim = claim && claim.reposted_claim;
         if (repostedClaim && returnRepost) {
-          const channelUrl = claim.signing_channel && claim.signing_channel.canonical_url;
+          const channelUrl = claim.signing_channel && (claim.signing_channel.canonical_url || claim.signing_channel.permanent_url);
 
           return {
             ...repostedClaim,


### PR DESCRIPTION
## Issue
Closes 5673 (lbry-desktop): `Reposts are all listed under "Annoymous"`