### PR TITLE
Revert "connection_status is dead, long live connected"

### DIFF
--- a/dist/flow-typed/Lbry.js
+++ b/dist/flow-typed/Lbry.js
@@ -7,6 +7,10 @@ declare type StatusResponse = {
     download_progress: number,
     downloading_headers: boolean,
   },
+  connection_status: {
+    code: string,
+    message: string,
+  },
   dht: {
     node_id: string,
     peers_in_routing_table: number,
@@ -41,7 +45,6 @@ declare type StatusResponse = {
     redirects: {},
   },
   wallet: ?{
-    connected: string,
     best_blockhash: string,
     blocks: number,
     blocks_behind: number,

--- a/flow-typed/Lbry.js
+++ b/flow-typed/Lbry.js
@@ -7,6 +7,10 @@ declare type StatusResponse = {
     download_progress: number,
     downloading_headers: boolean,
   },
+  connection_status: {
+    code: string,
+    message: string,
+  },
   dht: {
     node_id: string,
     peers_in_routing_table: number,
@@ -41,7 +45,6 @@ declare type StatusResponse = {
     redirects: {},
   },
   wallet: ?{
-    connected: string,
     best_blockhash: string,
     blocks: number,
     blocks_behind: number,


### PR DESCRIPTION
Reverts lbryio/lbry-redux#390

Will add this back once the desktop changes are made. It's causing lint to fail.