### PR TITLE
Drop old txo-fetch results

### DIFF
--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -81,8 +81,13 @@ export function doFetchTransactions(page = 1, pageSize = 99999) {
 
 export function doFetchTxoPage() {
   return (dispatch, getState) => {
+    const fetchId = Math.random()
+      .toString(36)
+      .substr(2, 9);
+
     dispatch({
       type: ACTIONS.FETCH_TXO_PAGE_STARTED,
+      data: fetchId,
     });
 
     const state = getState();
@@ -120,13 +125,19 @@ export function doFetchTxoPage() {
       .then(res => {
         dispatch({
           type: ACTIONS.FETCH_TXO_PAGE_COMPLETED,
-          data: res,
+          data: {
+            result: res,
+            fetchId: fetchId,
+          },
         });
       })
       .catch(e => {
         dispatch({
           type: ACTIONS.FETCH_TXO_PAGE_COMPLETED,
-          data: e.message,
+          data: {
+            error: e.message,
+            fetchId: fetchId,
+          },
         });
       });
   };

--- a/src/redux/reducers/wallet.js
+++ b/src/redux/reducers/wallet.js
@@ -47,6 +47,7 @@ type WalletState = {
   txoFetchParams: {},
   utxoCounts: {},
   txoPage: any,
+  fetchId: string,
   fetchingTxos: boolean,
   fetchingTxosError?: string,
   consolidatingUtxos: boolean,
@@ -99,6 +100,7 @@ const defaultState = {
   massClaimingTips: false,
   pendingMassClaimTxid: null,
   txoPage: {},
+  fetchId: '',
   fetchingTxos: false,
   fetchingTxosError: undefined,
   pendingSupportTransactions: {},
@@ -129,18 +131,26 @@ export const walletReducer = handleActions(
       };
     },
 
-    [ACTIONS.FETCH_TXO_PAGE_STARTED]: (state: WalletState) => {
+    [ACTIONS.FETCH_TXO_PAGE_STARTED]: (state: WalletState, action) => {
       return {
         ...state,
+        fetchId: action.data,
         fetchingTxos: true,
         fetchingTxosError: undefined,
       };
     },
 
     [ACTIONS.FETCH_TXO_PAGE_COMPLETED]: (state: WalletState, action) => {
+      if (state.fetchId !== action.data.fetchId) {
+        // Leave 'state' and 'fetchingTxos' alone. The latter would ensure
+        // the spiner would continue spinning for the latest transaction.
+        return { ...state };
+      }
+
       return {
         ...state,
-        txoPage: action.data,
+        txoPage: action.data.result,
+        fetchId: '',
         fetchingTxos: false,
       };
     },
@@ -149,6 +159,7 @@ export const walletReducer = handleActions(
       return {
         ...state,
         txoPage: {},
+        fetchId: '',
         fetchingTxos: false,
         fetchingTxosError: action.data,
       };


### PR DESCRIPTION
## Issue
Closes lbry-desktop [4317: Transaction list shows previously requested data / pages](https://github.com/lbryio/lbry-desktop/issues/4317)

## Approach
A naive approach of creating a random transaction ID for each fetch. The latest ID, stored in `state`, will be the expected one -- any other transaction results will be dropped.

The loading spinner will continue to spin until the latest ID's results are fetched.

## Sample
Example of 3 fast filter switches:
![image](https://user-images.githubusercontent.com/64950861/111640523-393fe680-8837-11eb-8725-d5afb15b895d.png)

## ??
This assumes there's no quick, built-in way to abort dispatched tasks (only did a quick Google search for it).  The ability to abort would speed up the wait-time.