### PR TITLE
support claim search async dispatch

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -4018,44 +4018,52 @@ function doClaimSearch(options = {
   page: 1
 }) {
   const query = createNormalizedClaimSearchKey(options);
-  return dispatch => {
-    dispatch({
-      type: CLAIM_SEARCH_STARTED,
-      data: { query: query }
+  return (() => {
+    var _ref2 = _asyncToGenerator$1(function* (dispatch) {
+      dispatch({
+        type: CLAIM_SEARCH_STARTED,
+        data: { query: query }
+      });
+
+      const success = function (data) {
+        const resolveInfo = {};
+        const urls = [];
+        data.items.forEach(function (stream) {
+          resolveInfo[stream.canonical_url] = { stream };
+          urls.push(stream.canonical_url);
+        });
+
+        dispatch({
+          type: CLAIM_SEARCH_COMPLETED,
+          data: {
+            query,
+            resolveInfo,
+            urls,
+            append: options.page && options.page !== 1,
+            pageSize: options.page_size
+          }
+        });
+        return true;
+      };
+
+      const failure = function (err) {
+        dispatch({
+          type: CLAIM_SEARCH_FAILED,
+          data: { query },
+          error: err
+        });
+        return false;
+      };
+
+      return yield lbryProxy.claim_search(_extends$5({}, options, {
+        include_purchase_receipt: true
+      })).then(success, failure);
     });
 
-    const success = data => {
-      const resolveInfo = {};
-      const urls = [];
-      data.items.forEach(stream => {
-        resolveInfo[stream.canonical_url] = { stream };
-        urls.push(stream.canonical_url);
-      });
-
-      dispatch({
-        type: CLAIM_SEARCH_COMPLETED,
-        data: {
-          query,
-          resolveInfo,
-          urls,
-          append: options.page && options.page !== 1,
-          pageSize: options.page_size
-        }
-      });
+    return function (_x2) {
+      return _ref2.apply(this, arguments);
     };
-
-    const failure = err => {
-      dispatch({
-        type: CLAIM_SEARCH_FAILED,
-        data: { query },
-        error: err
-      });
-    };
-
-    lbryProxy.claim_search(_extends$5({}, options, {
-      include_purchase_receipt: true
-    })).then(success, failure);
-  };
+  })();
 }
 
 function doRepost(options) {

--- a/src/redux/actions/claims.js
+++ b/src/redux/actions/claims.js
@@ -65,7 +65,7 @@ export function doResolveUris(
     } = {};
 
     return Lbry.resolve({ urls: urisToResolve, ...options }).then(
-      async (result: ResolveResponse) => {
+      async(result: ResolveResponse) => {
         let repostedResults = {};
         const repostsToResolve = [];
         const fallbackResolveInfo = {
@@ -594,7 +594,7 @@ export function doClaimSearch(
   }
 ) {
   const query = createNormalizedClaimSearchKey(options);
-  return (dispatch: Dispatch) => {
+  return async(dispatch: Dispatch) => {
     dispatch({
       type: ACTIONS.CLAIM_SEARCH_STARTED,
       data: { query: query },
@@ -618,6 +618,7 @@ export function doClaimSearch(
           pageSize: options.page_size,
         },
       });
+      return true;
     };
 
     const failure = err => {
@@ -626,9 +627,10 @@ export function doClaimSearch(
         data: { query },
         error: err,
       });
+      return false;
     };
 
-    Lbry.claim_search({
+    return await Lbry.claim_search({
       ...options,
       include_purchase_receipt: true,
     }).then(success, failure);


### PR DESCRIPTION
I wanted to call claim search from lbry-desktop and dispatch actions (isFetching) before and after success, so that the search, using --include_is_my_output would load results into myClaims.