### PR TITLE
doFetchTransactions: bump pageSize to 999999; remove doFetchSupport

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2906,9 +2906,8 @@ function doBalanceSubscribe() {
   };
 }
 
-function doFetchTransactions(page = 1, pageSize = 99999) {
+function doFetchTransactions(page = 1, pageSize = 999999) {
   return dispatch => {
-    dispatch(doFetchSupports());
     dispatch({
       type: FETCH_TRANSACTIONS_STARTED
     });
@@ -2987,23 +2986,6 @@ function doUpdateTxoPageParams(params) {
     });
 
     dispatch(doFetchTxoPage());
-  };
-}
-
-function doFetchSupports(page = 1, pageSize = 99999) {
-  return dispatch => {
-    dispatch({
-      type: FETCH_SUPPORTS_STARTED
-    });
-
-    lbryProxy.support_list({ page, page_size: pageSize }).then(result => {
-      dispatch({
-        type: FETCH_SUPPORTS_COMPLETED,
-        data: {
-          supports: result.items
-        }
-      });
-    });
   };
 }
 

--- a/src/redux/actions/wallet.js
+++ b/src/redux/actions/wallet.js
@@ -61,9 +61,8 @@ export function doBalanceSubscribe() {
   };
 }
 
-export function doFetchTransactions(page = 1, pageSize = 99999) {
+export function doFetchTransactions(page = 1, pageSize = 999999) {
   return dispatch => {
-    dispatch(doFetchSupports());
     dispatch({
       type: ACTIONS.FETCH_TRANSACTIONS_STARTED,
     });


### PR DESCRIPTION
## Issue
https://github.com/lbryio/lbry-desktop/pull/5899 Re-add ability to export transactions

## Note
I think this one was missed when merging in 5899.  Oddly, I couldn't find the PR for this item in the Closed section.  Either I forgot to create the PR, or something went wrong because I re-used an old branch name back then.

Anyway, re-created this PR with a new branch.

