### PR TITLE
Don't reset content language on edit

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -5414,8 +5414,9 @@ const selectIsStillEditing = reselect.createSelector(selectState$4, publishState
 });
 
 const selectPublishFormValues = reselect.createSelector(selectState$4, state => state.settings, selectIsStillEditing, (publishState, settingsState, isStillEditing) => {
-  const { pendingPublish, language } = publishState,
-        formValues = _objectWithoutProperties$2(publishState, ['pendingPublish', 'language']);
+  const { languages } = publishState,
+        formValues = _objectWithoutProperties$2(publishState, ['languages']);
+  const language = languages[0];
   const { clientSettings } = settingsState;
   const { language: languageSet } = clientSettings;
 

--- a/src/redux/selectors/publish.js
+++ b/src/redux/selectors/publish.js
@@ -43,7 +43,8 @@ export const selectPublishFormValues = createSelector(
   state => state.settings,
   selectIsStillEditing,
   (publishState, settingsState, isStillEditing) => {
-    const { pendingPublish, language, ...formValues } = publishState;
+    const { languages, ...formValues } = publishState;
+    const language = languages[0];
     const { clientSettings } = settingsState;
     const { language: languageSet } = clientSettings;
 


### PR DESCRIPTION
## Issue

Publish page tries to set the upload language to the user langauge, and it does so on edit and overwrites the existing value.
https://github.com/lbryio/lbry-desktop/issues/6132

## Change

selectPublishFormValues was trying to return "language" from formValues but would always return false, and set the language as default instead, should return "languages" instead.
Also "pendingPublish" was unused