### PR TITLE
Fix Object.fromEntries crash on some browsers

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2,9 +2,12 @@
 
 Object.defineProperty(exports, '__esModule', { value: true });
 
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
 require('proxy-polyfill');
 var uuid = require('uuid');
 var reselect = require('reselect');
+var fromEntries = _interopDefault(require('@ungap/from-entries'));
 
 const MINIMUM_PUBLISH_BID = 0.00000001;
 
@@ -3648,7 +3651,7 @@ const makeSelectCollectionIsMine = id => reselect.createSelector(selectMyCollect
 
 const selectMyPublishedCollections = reselect.createSelector(selectResolvedCollections, selectPendingCollections, selectMyEditedCollections, selectMyCollectionIds, (resolved, pending, edited, myIds) => {
   // all resolved in myIds, plus those in pending and edited
-  const myPublishedCollections = Object.fromEntries(Object.entries(pending).concat(Object.entries(resolved).filter(([key, val]) => myIds.includes(key) &&
+  const myPublishedCollections = fromEntries(Object.entries(pending).concat(Object.entries(resolved).filter(([key, val]) => myIds.includes(key) &&
   // $FlowFixMe
   !pending[key])));
   // now add in edited:
@@ -3659,7 +3662,7 @@ const selectMyPublishedCollections = reselect.createSelector(selectResolvedColle
 });
 
 const selectMyPublishedMixedCollections = reselect.createSelector(selectMyPublishedCollections, published => {
-  const myCollections = Object.fromEntries(
+  const myCollections = fromEntries(
   // $FlowFixMe
   Object.entries(published).filter(([key, collection]) => {
     // $FlowFixMe
@@ -3669,7 +3672,7 @@ const selectMyPublishedMixedCollections = reselect.createSelector(selectMyPublis
 });
 
 const selectMyPublishedPlaylistCollections = reselect.createSelector(selectMyPublishedCollections, published => {
-  const myCollections = Object.fromEntries(
+  const myCollections = fromEntries(
   // $FlowFixMe
   Object.entries(published).filter(([key, collection]) => {
     // $FlowFixMe
@@ -3684,7 +3687,7 @@ const makeSelectMyPublishedCollectionForId = id => reselect.createSelector(selec
 //   selectResolvedCollections,
 //   selectSavedCollectionIds,
 //   (resolved, myIds) => {
-//     const mySavedCollections = Object.fromEntries(
+//     const mySavedCollections = fromEntries(
 //       Object.entries(resolved).filter(([key, val]) => myIds.includes(key))
 //     );
 //     return mySavedCollections;

--- a/dist/flow-typed/npm/from-entries.js
+++ b/dist/flow-typed/npm/from-entries.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare module '@ungap/from-entries' {
+  declare module.exports: any;
+}

--- a/flow-typed/npm/from-entries.js
+++ b/flow-typed/npm/from-entries.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare module '@ungap/from-entries' {
+  declare module.exports: any;
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@ungap/from-entries": "^0.2.1",
     "proxy-polyfill": "0.1.6",
     "reselect": "^3.0.0",
     "uuid": "^8.3.1"

--- a/src/redux/selectors/collections.js
+++ b/src/redux/selectors/collections.js
@@ -1,4 +1,5 @@
 // @flow
+import fromEntries from '@ungap/from-entries';
 import { createSelector } from 'reselect';
 import {
   selectMyCollectionIds,
@@ -79,7 +80,7 @@ export const selectMyPublishedCollections = createSelector(
   selectMyCollectionIds,
   (resolved, pending, edited, myIds) => {
     // all resolved in myIds, plus those in pending and edited
-    const myPublishedCollections = Object.fromEntries(
+    const myPublishedCollections = fromEntries(
       Object.entries(pending).concat(
         Object.entries(resolved).filter(
           ([key, val]) =>
@@ -100,7 +101,7 @@ export const selectMyPublishedCollections = createSelector(
 export const selectMyPublishedMixedCollections = createSelector(
   selectMyPublishedCollections,
   published => {
-    const myCollections = Object.fromEntries(
+    const myCollections = fromEntries(
       // $FlowFixMe
       Object.entries(published).filter(([key, collection]) => {
         // $FlowFixMe
@@ -114,7 +115,7 @@ export const selectMyPublishedMixedCollections = createSelector(
 export const selectMyPublishedPlaylistCollections = createSelector(
   selectMyPublishedCollections,
   published => {
-    const myCollections = Object.fromEntries(
+    const myCollections = fromEntries(
       // $FlowFixMe
       Object.entries(published).filter(([key, collection]) => {
         // $FlowFixMe
@@ -135,7 +136,7 @@ export const makeSelectMyPublishedCollectionForId = (id: string) =>
 //   selectResolvedCollections,
 //   selectSavedCollectionIds,
 //   (resolved, myIds) => {
-//     const mySavedCollections = Object.fromEntries(
+//     const mySavedCollections = fromEntries(
 //       Object.entries(resolved).filter(([key, val]) => myIds.includes(key))
 //     );
 //     return mySavedCollections;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,6 +1411,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@ungap/from-entries@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@ungap/from-entries/-/from-entries-0.2.1.tgz#7e86196b8b2e99d73106a8f25c2a068326346354"
+  integrity sha512-CAqefTFAfnUPwYqsWHXpOxHaq1Zo5UQ3m9Zm2p09LggGe57rqHoBn3c++xcoomzXKynAUuiBMDUCQvKMnXjUpA==
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"


### PR DESCRIPTION
## Issue
#6985 fromentries app crash - fix or add polyfill

## Notes
Did some guessing, so please verify.
- Added the flow entry, otherwise lint couldn't find the module.  Is this normal?